### PR TITLE
Avoid possible null pointer dereferencing in tcp connection

### DIFF
--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -184,8 +184,9 @@ static void OnConnection(uv_stream_t* handle, int status) {
         iotjs_jval_get_object_native_handle(jclient_tcp,
                                             &this_module_native_info);
 
-    int err = uv_accept(handle, (uv_stream_t*)client_handle);
-    if (err) {
+
+    if (client_handle == NULL ||
+        uv_accept(handle, (uv_stream_t*)client_handle)) {
       jerry_release_value(args[0]);
       return;
     }


### PR DESCRIPTION
The `iotjs_jval_get_object_native_handle` function call might return with NULL, so there is a possible null pointer dereferencing in the `uv_accept` call.