### PR TITLE
Disable C4668 MSVC warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,10 @@ if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
   set(CONFIG_TYPE $<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>)
   # disable warning C4820: 'x' bytes padding added after construct 'membername'
   iotjs_add_compile_flags(-wd4820)
+  # disable warning C4668: 'symbol' is not defined as preprocessor macro,
+  #   replacing with '0' for 'directives'
+  # some windows headers reports these warnings
+  iotjs_add_compile_flags(-wd4668)
 endif()
 
 CHECK_C_COMPILER_FLAG(-no-pie HAS_NO_PIE)


### PR DESCRIPTION
Quite a few C4668 warnings are reported during Windows build which
are from SDK/system libraries. As the SDK/system headers should not
be modified by the IoT.js project, it is possible to get rid of them
by explicitly disabling the warning in the main CMake file.

An example for the warning:
```
c:\program files (x86)\windows kits\10\include\10.0.17134.0\um\winioctl.h(8951):
warning C4668: '_WIN32_WINNT_WIN10_RS3' is not defined as a preprocessor macro,
replacing with '0' for '#if/#elif'
```