### PR TITLE
Fix Windows warning C4255

### DIFF
--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -294,7 +294,7 @@ foreach(MODULE ${IOTJS_NATIVE_MODULES})
   string(TOLOWER ${MODULE} module)
 
   set(IOTJS_MODULE_INITIALIZERS "${IOTJS_MODULE_INITIALIZERS}
-extern jerry_value_t ${${IOTJS_MODULES_JSON}.modules.${module}.init}();")
+extern jerry_value_t ${${IOTJS_MODULES_JSON}.modules.${module}.init}(void);")
 endforeach()
 
 # Build up module entries

--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -68,7 +68,7 @@ void iotjs_process_emit_exit(int code) {
 
 
 // Calls next tick callbacks registered via `process.nextTick()`.
-bool iotjs_process_next_tick() {
+bool iotjs_process_next_tick(void) {
   iotjs_environment_t* env = iotjs_environment_get();
 
   if (iotjs_environment_is_exiting(env)) {
@@ -133,7 +133,7 @@ jerry_value_t iotjs_invoke_callback_with_result(jerry_value_t jfunc,
 }
 
 
-int iotjs_process_exitcode() {
+int iotjs_process_exitcode(void) {
   const jerry_value_t process = iotjs_module_get("process");
 
   jerry_value_t jexitcode =

--- a/src/iotjs_binding_helper.h
+++ b/src/iotjs_binding_helper.h
@@ -24,7 +24,7 @@ void iotjs_uncaught_exception(jerry_value_t jexception);
 
 void iotjs_process_emit_exit(int code);
 
-bool iotjs_process_next_tick();
+bool iotjs_process_next_tick(void);
 
 void iotjs_invoke_callback(jerry_value_t jfunc, jerry_value_t jthis,
                            const jerry_value_t* jargv, size_t jargc);
@@ -33,7 +33,7 @@ jerry_value_t iotjs_invoke_callback_with_result(jerry_value_t jfunc,
                                                 const jerry_value_t* jargv,
                                                 size_t jargc);
 
-int iotjs_process_exitcode();
+int iotjs_process_exitcode(void);
 void iotjs_set_process_exitcode(int code);
 
 #endif /* IOTJS_BINDING_HELPER_H */

--- a/src/iotjs_debuglog.c
+++ b/src/iotjs_debuglog.c
@@ -31,7 +31,7 @@ const char* iotjs_debug_prefix[4] = { "", "ERR", "WRN", "INF" };
 #endif // ENABLE_DEBUG_LOG
 
 
-void iotjs_debuglog_init() {
+void iotjs_debuglog_init(void) {
 #ifdef ENABLE_DEBUG_LOG
   const char* dbglevel = NULL;
   const char* dbglogfile = NULL;
@@ -59,7 +59,7 @@ void iotjs_debuglog_init() {
 #endif // ENABLE_DEBUG_LOG
 }
 
-void iotjs_debuglog_release() {
+void iotjs_debuglog_release(void) {
 #ifdef ENABLE_DEBUG_LOG
   if (iotjs_log_stream && iotjs_log_stream != stderr &&
       iotjs_log_stream != stdout) {

--- a/src/iotjs_debuglog.h
+++ b/src/iotjs_debuglog.h
@@ -78,8 +78,8 @@ extern const char* iotjs_debug_prefix[4];
 #endif /* ENABLE_DEBUG_LOG */
 
 
-void iotjs_debuglog_init();
-void iotjs_debuglog_release();
+void iotjs_debuglog_init(void);
+void iotjs_debuglog_release(void);
 
 
 #endif /* IOTJS_DEBUGLOG_H */

--- a/src/iotjs_def.h
+++ b/src/iotjs_def.h
@@ -33,8 +33,8 @@
 #ifdef NDEBUG
 #define IOTJS_ASSERT(x) ((void)(x))
 #else /* !NDEBUG */
-extern void print_stacktrace();
-extern void force_terminate();
+extern void print_stacktrace(void);
+extern void force_terminate(void);
 #define IOTJS_ASSERT(x)                                                      \
   do {                                                                       \
     if (!(x)) {                                                              \

--- a/src/iotjs_env.c
+++ b/src/iotjs_env.c
@@ -51,7 +51,7 @@ static void initialize(iotjs_environment_t* env);
 /**
  * Get the singleton instance of iotjs_environment_t.
  */
-iotjs_environment_t* iotjs_environment_get() {
+iotjs_environment_t* iotjs_environment_get(void) {
   if (!initialized) {
     initialize(&current_env);
     initialized = true;
@@ -63,7 +63,7 @@ iotjs_environment_t* iotjs_environment_get() {
 /**
  * Release the singleton instance of iotjs_environment_t, and debugger config.
  */
-void iotjs_environment_release() {
+void iotjs_environment_release(void) {
   if (!initialized)
     return;
 

--- a/src/iotjs_env.h
+++ b/src/iotjs_env.h
@@ -63,8 +63,8 @@ typedef struct {
 } iotjs_environment_t;
 
 
-iotjs_environment_t* iotjs_environment_get();
-void iotjs_environment_release();
+iotjs_environment_t* iotjs_environment_get(void);
+void iotjs_environment_release(void);
 
 bool iotjs_environment_parse_command_line_arguments(iotjs_environment_t* env,
                                                     uint32_t argc, char** argv);

--- a/src/iotjs_module.c
+++ b/src/iotjs_module.c
@@ -27,7 +27,7 @@ typedef struct { jerry_value_t jmodule; } iotjs_module_rw_data_t;
  *  - iotjs_module_rw_data[]
  */
 
-void iotjs_module_list_cleanup() {
+void iotjs_module_list_cleanup(void) {
   for (unsigned i = 0; i < iotjs_module_count; i++) {
     if (iotjs_module_rw_data[i].jmodule != 0) {
       jerry_release_value(iotjs_module_rw_data[i].jmodule);

--- a/src/iotjs_module.h
+++ b/src/iotjs_module.h
@@ -18,7 +18,7 @@
 
 #include "iotjs_binding.h"
 
-typedef jerry_value_t (*register_func)();
+typedef jerry_value_t (*register_func)(void);
 
 typedef struct {
   const char* name;
@@ -28,7 +28,7 @@ typedef struct {
 extern const unsigned iotjs_module_count;
 extern const iotjs_module_ro_data_t iotjs_module_ro_data[];
 
-void iotjs_module_list_cleanup();
+void iotjs_module_list_cleanup(void);
 
 jerry_value_t iotjs_module_get(const char* name);
 

--- a/src/iotjs_string.c
+++ b/src/iotjs_string.c
@@ -21,7 +21,7 @@
 #include <string.h>
 
 
-iotjs_string_t iotjs_string_create() {
+iotjs_string_t iotjs_string_create(void) {
   iotjs_string_t str;
 
   str.size = 0;

--- a/src/iotjs_string.h
+++ b/src/iotjs_string.h
@@ -23,7 +23,7 @@ typedef struct {
 } iotjs_string_t;
 
 // Create new string
-iotjs_string_t iotjs_string_create();
+iotjs_string_t iotjs_string_create(void);
 iotjs_string_t iotjs_string_create_with_size(const char* data, size_t size);
 iotjs_string_t iotjs_string_create_with_buffer(char* buffer, size_t size);
 

--- a/src/iotjs_util.c
+++ b/src/iotjs_util.c
@@ -25,7 +25,7 @@
 #include <execinfo.h>
 #endif
 
-void force_terminate();
+void force_terminate(void);
 
 iotjs_string_t iotjs_file_read(const char* path) {
   FILE* file = fopen(path, "rb");
@@ -114,7 +114,7 @@ void iotjs_buffer_release(char* buffer) {
   }
 }
 
-void print_stacktrace() {
+void print_stacktrace(void) {
 #if defined(__linux__) && defined(DEBUG) && !defined(__OPENWRT__)
   // TODO: support other platforms
   const int numOfStackTrace = 100;
@@ -150,6 +150,6 @@ void print_stacktrace() {
 #endif // defined(__linux__) && defined(DEBUG) && !defined(__OPENWRT__)
 }
 
-void force_terminate() {
+void force_terminate(void) {
   exit(EXIT_FAILURE);
 }

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -747,7 +747,7 @@ JS_FUNCTION(FromArrayBuffer) {
 }
 
 
-jerry_value_t InitBuffer() {
+jerry_value_t InitBuffer(void) {
   jerry_value_t buffer = jerry_create_external_function(Buffer);
   iotjs_jval_set_method(buffer, IOTJS_MAGIC_STRING_BYTELENGTH, ByteLength);
   iotjs_jval_set_method(buffer, IOTJS_MAGIC_STRING_COMPARE, Compare);

--- a/src/modules/iotjs_module_console.c
+++ b/src/modules/iotjs_module_console.c
@@ -54,7 +54,7 @@ JS_FUNCTION(Stderr) {
 }
 
 
-jerry_value_t InitConsole() {
+jerry_value_t InitConsole(void) {
   jerry_value_t console = jerry_create_object();
 
   iotjs_jval_set_method(console, IOTJS_MAGIC_STRING_STDOUT, Stdout);

--- a/src/modules/iotjs_module_constants.c
+++ b/src/modules/iotjs_module_constants.c
@@ -22,7 +22,7 @@
     iotjs_jval_set_property_number(object, #constant, constant); \
   } while (0)
 
-jerry_value_t InitConstants() {
+jerry_value_t InitConstants(void) {
   jerry_value_t constants = jerry_create_object();
 
   SET_CONSTANT(constants, O_APPEND);

--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -209,7 +209,7 @@ JS_FUNCTION(GetAddressInfo) {
   } while (0)
 
 
-jerry_value_t InitDns() {
+jerry_value_t InitDns(void) {
   jerry_value_t dns = jerry_create_object();
 
   iotjs_jval_set_method(dns, IOTJS_MAGIC_STRING_GETADDRINFO, GetAddressInfo);

--- a/src/modules/iotjs_module_fs.c
+++ b/src/modules/iotjs_module_fs.c
@@ -470,7 +470,7 @@ JS_FUNCTION(StatsIsFile) {
   return StatsIsTypeOf(stats, S_IFREG);
 }
 
-jerry_value_t InitFs() {
+jerry_value_t InitFs(void) {
   jerry_value_t fs = jerry_create_object();
 
   iotjs_jval_set_method(fs, IOTJS_MAGIC_STRING_CLOSE, Close);

--- a/src/modules/iotjs_module_http_parser.c
+++ b/src/modules/iotjs_module_http_parser.c
@@ -471,7 +471,7 @@ static void http_parser_register_methods_object(jerry_value_t target) {
   jerry_release_value(methods);
 }
 
-jerry_value_t InitHttpParser() {
+jerry_value_t InitHttpParser(void) {
   jerry_value_t http_parser = jerry_create_object();
 
   jerry_value_t jParserCons = jerry_create_external_function(HTTPParserCons);

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -362,7 +362,7 @@ static void SetProcessPrivate(jerry_value_t process, bool wait_source) {
 }
 
 
-jerry_value_t InitProcess() {
+jerry_value_t InitProcess(void) {
   jerry_value_t process = jerry_create_object();
 
   iotjs_jval_set_method(process, IOTJS_MAGIC_STRING_CWD, Cwd);

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -411,7 +411,7 @@ JS_FUNCTION(GetSockeName) {
   return jerry_create_number(err);
 }
 
-jerry_value_t InitTcp() {
+jerry_value_t InitTcp(void) {
   jerry_value_t tcp = jerry_create_external_function(TCP);
 
   jerry_value_t prototype = jerry_create_object();

--- a/src/modules/iotjs_module_timer.c
+++ b/src/modules/iotjs_module_timer.c
@@ -78,7 +78,7 @@ JS_FUNCTION(Timer) {
 }
 
 
-jerry_value_t InitTimer() {
+jerry_value_t InitTimer(void) {
   jerry_value_t timer = jerry_create_external_function(Timer);
 
   jerry_value_t prototype = jerry_create_object();


### PR DESCRIPTION
On Windows there is a warning (C4255) which notifies the developer
if the function argument is empty and no 'void' is specified.

Example warning:
'InitTcp': no function prototype given: converting '()' to '(void)'

The change adds the 'void' specifier for such methods.