### PR TITLE
Add missing requirement for Windows build document

### DIFF
--- a/docs/build/Build-for-Windows.md
+++ b/docs/build/Build-for-Windows.md
@@ -17,6 +17,7 @@ Check if the following tools are installed:
  * GIT
  * Visual Studio 2017 with C++ support
  * Python 3
+ * CMake
 
 Additionally clone the IoT.js repository into a convenient directory.
 In the document the `C:\dev\iotjs` path will be used as an example.


### PR DESCRIPTION
The CMake requirement was not specified in the Windows build document.
Without this it could lead to an awkward situation that the developer
does not know what is the problem during the build.