### PR TITLE
Removed an unnecessary 'do { } while(0);' from HTTP parser module.

### DIFF
--- a/src/modules/iotjs_module_http_parser.c
+++ b/src/modules/iotjs_module_http_parser.c
@@ -457,14 +457,12 @@ static void http_parser_register_methods_object(jerry_value_t target) {
 
   jerry_value_t method_name;
   uint32_t idx = 0;
-#define V(num, name, string)                                         \
-  do {                                                               \
-    method_name = jerry_create_string((const jerry_char_t*)#string); \
-    jerry_set_property_by_index(methods, idx++, method_name);        \
-    jerry_release_value(method_name);                                \
-  } while (0);
+#define V(num, name, string)                                       \
+  method_name = jerry_create_string((const jerry_char_t*)#string); \
+  jerry_set_property_by_index(methods, idx++, method_name);        \
+  jerry_release_value(method_name);
 
-  HTTP_METHOD_MAP(V)
+  HTTP_METHOD_MAP(V);
 #undef V
 
   iotjs_jval_set_property_jval(target, IOTJS_MAGIC_STRING_METHODS, methods);


### PR DESCRIPTION
Usually 'do { } while(0)' without a semicolon is used in a macro when we want
to force the semicolon for the certain macro. The compiler does fails if the
developer forgot the semicolon after the macro call. Using this technique with
a semicolon after the 'while' has no sense ('...while(0);').

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com