### PR TITLE
Implemented 'napi_create_symbol' and added ES2015 related tests for N-API

### DIFF
--- a/src/napi/node_api_value.c
+++ b/src/napi/node_api_value.c
@@ -230,6 +230,21 @@ DEF_NAPI_NUMBER_CONVERT_FROM_NVALUE(int64_t, int64);
 DEF_NAPI_NUMBER_CONVERT_FROM_NVALUE(uint32_t, uint32);
 #undef DEF_NAPI_NUMBER_CONVERT_FROM_NVALUE
 
+napi_status napi_create_symbol(napi_env env, napi_value description,
+                               napi_value* result) {
+  NAPI_TRY_ENV(env);
+
+  if (!jerry_is_feature_enabled(JERRY_FEATURE_SYMBOL)) {
+    NAPI_ASSIGN(result, NULL);
+    NAPI_RETURN(napi_generic_failure,
+                "Symbols are not supported by this build.");
+  }
+
+  JERRYX_CREATE(jval, jerry_create_symbol(AS_JERRY_VALUE(description)));
+  NAPI_ASSIGN(result, AS_NAPI_VALUE(jval));
+  NAPI_RETURN(napi_ok);
+}
+
 napi_status napi_create_string_utf8(napi_env env, const char* str,
                                     size_t length, napi_value* result) {
   NAPI_TRY_ENV(env);
@@ -384,6 +399,10 @@ napi_status napi_typeof(napi_env env, napi_value value,
     }
     case JERRY_TYPE_STRING: {
       NAPI_ASSIGN(result, napi_string);
+      break;
+    }
+    case JERRY_TYPE_SYMBOL: {
+      NAPI_ASSIGN(result, napi_symbol);
       break;
     }
     case JERRY_TYPE_OBJECT: {

--- a/test/napi/binding.gyp
+++ b/test/napi/binding.gyp
@@ -67,6 +67,10 @@
     {
       "target_name": "test_napi_string",
       "sources": [ "test_napi_string.c" ]
+    },
+    {
+      "target_name": "test_napi_symbol",
+      "sources": [ "test_napi_symbol.c" ]
     }
   ]
 }

--- a/test/napi/test_napi_general_es2015.js
+++ b/test/napi/test_napi_general_es2015.js
@@ -1,0 +1,42 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+var assert = require('assert');
+
+var test_general = require('./build/Release/test_napi_general.node');
+
+assert.strictEqual(test_general.GetUndefined(), undefined);
+assert.strictEqual(test_general.GetNull(), null);
+
+var buffer = new ArrayBuffer(16);
+
+[
+  buffer,
+  new Int8Array(buffer),
+  new Uint8Array(buffer),
+  new Uint8ClampedArray(buffer),
+  new Int16Array(buffer),
+  new Uint16Array(buffer),
+  new Int32Array(buffer),
+  new Uint32Array(buffer),
+  new Float32Array(buffer),
+  new Float64Array(buffer),
+
+  new Promise(function(){}),
+  Symbol(),
+].forEach(function(val) {
+  assert.strictEqual(test_general.TypeOf(val), typeof val);
+});

--- a/test/napi/test_napi_symbol.c
+++ b/test/napi/test_napi_symbol.c
@@ -1,0 +1,38 @@
+#include "common.h"
+#include "node_api.h"
+
+static napi_value create_symbol(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  napi_value description = NULL;
+  if (argc >= 1) {
+    napi_valuetype valuetype;
+    NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+
+    NAPI_ASSERT(env, valuetype == napi_string,
+                "Wrong type of arguments. Expects a string.");
+
+    description = args[0];
+  }
+
+  napi_value symbol;
+  NAPI_CALL(env, napi_create_symbol(env, description, &symbol));
+
+  return symbol;
+}
+
+static napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor properties[] = {
+    DECLARE_NAPI_PROPERTY("CreateSymbol", create_symbol),
+  };
+
+  NAPI_CALL(env, napi_define_properties(env, exports, sizeof(properties) /
+                                                          sizeof(*properties),
+                                        properties));
+
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/napi/test_napi_symbol.js
+++ b/test/napi/test_napi_symbol.js
@@ -1,0 +1,48 @@
+'use strict';
+var assert = require('assert');
+
+// testing api calls for symbol
+var test_symbol = require('./build/Release/test_napi_symbol.node');
+
+var sym = test_symbol.CreateSymbol('test');
+assert.strictEqual(sym.toString(), 'Symbol(test)');
+
+{
+  var myObj = {};
+  var fooSym = test_symbol.CreateSymbol('foo');
+  var otherSym = test_symbol.CreateSymbol('bar');
+  myObj.foo = 'bar';
+  myObj[fooSym] = 'baz';
+  myObj[otherSym] = 'bing';
+  assert.strictEqual(myObj.foo, 'bar');
+  assert.strictEqual(myObj[fooSym], 'baz');
+  assert.strictEqual(myObj[otherSym], 'bing');
+}
+
+{
+  var fooSym = test_symbol.CreateSymbol('foo');
+  var myObj = {};
+  myObj.foo = 'bar';
+  myObj[fooSym] = 'baz';
+  Object.keys(myObj); // -> [ 'foo' ]
+  Object.getOwnPropertyNames(myObj); // -> [ 'foo' ]
+  Object.getOwnPropertySymbols(myObj); // -> [ Symbol(foo) ]
+  assert.strictEqual(Object.getOwnPropertySymbols(myObj)[0], fooSym);
+}
+
+{
+  assert.notStrictEqual(test_symbol.CreateSymbol(), test_symbol.CreateSymbol());
+  assert.notStrictEqual(test_symbol.CreateSymbol('foo'),
+                        test_symbol.CreateSymbol('foo'));
+  assert.notStrictEqual(test_symbol.CreateSymbol('foo'),
+                        test_symbol.CreateSymbol('bar'));
+
+  var foo1 = test_symbol.CreateSymbol('foo');
+  var foo2 = test_symbol.CreateSymbol('foo');
+  var object = {
+    [foo1]: 1,
+    [foo2]: 2,
+  };
+  assert.strictEqual(object[foo1], 1);
+  assert.strictEqual(object[foo2], 2);
+}

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -1257,6 +1257,18 @@
       ]
     },
     {
+      "name": "test_napi_general_es2015.js",
+      "required-features": [
+        "ArrayBuffer",
+        "Promise",
+        "Symbol",
+        "TypedArray"
+      ],
+      "required-modules": [
+        "napi"
+      ]
+    },
+    {
       "name": "test_napi_handle_scope.js",
       "required-modules": [
         "napi"
@@ -1306,6 +1318,15 @@
     },
     {
       "name": "test_napi_string.js",
+      "required-modules": [
+        "napi"
+      ]
+    },
+    {
+      "name": "test_napi_symbol.js",
+      "required-features": [
+        "Symbol"
+      ],
       "required-modules": [
         "napi"
       ]

--- a/test/tools/iotjs_build_info.js
+++ b/test/tools/iotjs_build_info.js
@@ -47,13 +47,16 @@ var typedArrayFeatures = [
   'Int8Array',
   'Uint8Array',
   'Uint8ClampedArray',
-  'Int168Array',
+  'Int16Array',
   'Uint16Array',
   'Int32Array',
   'Uint32Array',
   'Float32Array',
   'Float64Array'
 ];
+
+if (hasFeatures(global, ['Symbol']))
+  features.Symbol = true;
 
 if (hasFeatures(global, ['Promise']))
   features.Promise = true;

--- a/tools/travis_script.py
+++ b/tools/travis_script.py
@@ -138,10 +138,17 @@ def job_host_linux():
 def job_n_api():
     start_container()
 
+    # N-API should work with both ES5.1 and ES2015-subset JerryScript profiles
     for buildtype in BUILDTYPES:
         build_iotjs(buildtype, [
                     '--run-test=full',
                     '--n-api'])
+
+    for buildtype in BUILDTYPES:
+        build_iotjs(buildtype, [
+                    '--run-test=full',
+                    '--n-api',
+                    '--jerry-profile=es2015-subset'])
 
 @job('mock-linux')
 def job_mock_linux():


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com