### PR TITLE
nuttx: Remove unnecessary include in ADC module

### DIFF
--- a/src/modules/nuttx/iotjs_module_adc-nuttx.c
+++ b/src/modules/nuttx/iotjs_module_adc-nuttx.c
@@ -24,7 +24,6 @@
 #include "iotjs_def.h"
 #include "iotjs_systemio-nuttx.h"
 #include "modules/iotjs_module_adc.h"
-#include "modules/iotjs_module_stm32f4dis.h"
 
 #define ADC_DEVICE_PATH_FORMAT "/dev/adc%d"
 #define ADC_DEVICE_PATH_BUFFER_SIZE 12


### PR DESCRIPTION
Currently that platform header defines only one function:
"iotjs_stm32f4dis_pin_initialize".

It's platform specific and called elsewhere:
./src/modules/iotjs_module_stm32f4dis.c

So it's safe to remove this probable leftover
to support more boards (STMF7 ones to come).

Change-Id: If22dbf1797fec20161203661b044845f55d2e378
Relate-to: https://github.com/rzr/webthing-iotjs/issues/3
IoT.js-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com