### PR TITLE
Improved N-API and Windows support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,8 @@ if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
   #   replacing with '0' for 'directives'
   # some windows headers reports these warnings
   iotjs_add_compile_flags(-wd4668)
+  # disable warning C4100: unreferenced formal parameter
+  iotjs_add_compile_flags(-wd4100)
 endif()
 
 CHECK_C_COMPILER_FLAG(-no-pie HAS_NO_PIE)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,18 +11,33 @@ configuration:
   - Release
 platform:
   - Win32
+  - x64
 init:
   - cmd: |
       cmake -version
-before_build:
-  - cmd: |
-      tools\build.py --experimental --buildtype=debug
+
+install:
+  - ps: |
+      Install-Product node 10.15.3
 
 artifacts:
-  - path: build\i686-windows\debug\bin\$(configuration)\
+  - path: build\x86_64-windows\$(configuration)\bin\$(configuration)\
     name: IoTjsbinary
 
+before_build:
+  - cmd: |
+      if "%PLATFORM%"=="Win32" set SYS_ARCH=i686
+      if "%PLATFORM%"=="x64" set SYS_ARCH=x86_64
+      tools\build.py --experimental --buildtype=%CONFIGURATION% --target-arch=%SYS_ARCH% --jerry-profile=es2015-subset --n-api
+
 build:
-  project: build\i686-windows\debug\IOTJS.sln
+  project: build\%SYS_ARCH%-windows\%CONFIGURATION%\IOTJS.sln
   parallel: true
   verbosity: minimal
+
+before_test:
+  - cmd: npm install
+
+test_script:
+  - cmd: |
+      tools\testrunner.py build\%SYS_ARCH%-windows\%CONFIGURATION%\bin\%CONFIGURATION%\iotjs.exe

--- a/test/node/common.js
+++ b/test/node/common.js
@@ -47,7 +47,7 @@ var testRoot = __dirname;
 
 // PORT should match the definition in test/testpy/__init__.py.
 exports.PORT = +process.env.NODE_COMMON_PORT || 12346;
-exports.isWindows = process.platform === 'win32';
+exports.isWindows = process.platform === 'windows';
 exports.isWOW64 = exports.isWindows &&
                   (process.env.PROCESSOR_ARCHITEW6432 !== undefined);
 exports.isAix = process.platform === 'aix';

--- a/test/node/parallel/test-net-bind-twice.js
+++ b/test/node/parallel/test-net-bind-twice.js
@@ -51,6 +51,8 @@ server1.listen(0, '127.0.0.1', common.mustCall(function() {
       assert.strictEqual(e, -48);
     } else if (common.isNuttX) {
       assert.strictEqual(e, -112);
+    } else if (common.isWindows) {
+      assert.strictEqual(e, -4091);
     } else {
       assert.strictEqual(e, -98);
     }

--- a/test/run_pass/test_net_7.js
+++ b/test/run_pass/test_net_7.js
@@ -24,7 +24,7 @@ var count = 40;
 var connectionCount = 0;
 
 if (process.platform === 'linux' || process.platform === 'darwin' ||
-    process.platform === 'tizen') {
+    process.platform === 'tizen' || process.platform === 'windows') {
   var maxConnection = 40;
 } else if (process.platform === 'nuttx' || process.platform === 'tizenrt') {
   var maxConnection = 5;

--- a/test/tools/iotjs_build_info.js
+++ b/test/tools/iotjs_build_info.js
@@ -77,7 +77,8 @@ result = {
     'builtins': builtins,
     'features': features,
     'stability': stability,
-    'debug': !!process.debug
+    'debug': !!process.debug,
+    'arch': process.arch
 }
 
 console.log(JSON.stringify(result))

--- a/tools/build.py
+++ b/tools/build.py
@@ -31,7 +31,7 @@ from common_py import path
 from common_py.system.filesystem import FileSystem as fs
 from common_py.system.executor import Executor as ex
 from common_py.system.executor import Terminal
-from common_py.system.platform import Platform
+from common_py.system.sys_platform import Platform
 
 platform = Platform()
 
@@ -58,7 +58,7 @@ def init_options():
         if (opt_key in list_with_commas) and isinstance(opt_val, list):
             opt_val and argv.append('--%s=%s' % (opt_key, ','.join(opt_val)))
         elif isinstance(opt_val, basestring) and opt_val != '':
-            argv.append('--%s=%s' % (opt_key, opt_val))
+            argv.append(str('--%s=%s' % (opt_key, opt_val)))
         elif isinstance(opt_val, bool):
             if opt_val:
                 argv.append('--%s' % opt_key)
@@ -78,7 +78,7 @@ def init_options():
     iotjs_group = parser.add_argument_group('Arguments of IoT.js',
         'The following arguments are related to the IoT.js framework.')
     iotjs_group.add_argument('--buildtype',
-        choices=['debug', 'release'], default='debug',
+        choices=['debug', 'release'], default='debug', type=str.lower,
         help='Specify the build type (default: %(default)s).')
     iotjs_group.add_argument('--builddir', default=path.BUILD_ROOT,
         help='Specify the build directory (default: %(default)s)')
@@ -290,6 +290,8 @@ def build_cmake_args(options):
         include_dirs.append('%s/../framework/include/iotbus' % options.sysroot)
     elif options.target_os == 'windows':
         cmake_args.append("-GVisual Studio 15 2017")
+        if options.target_arch == "x86_64":
+            cmake_args.append("-Ax64")
 
     include_dirs.extend(options.external_include_dir)
     cmake_args.append("-DEXTERNAL_INCLUDE_DIR='%s'" % (' '.join(include_dirs)))
@@ -406,9 +408,6 @@ def run_checktest(options):
 
     if options.run_test == "quiet":
         args.append('--quiet')
-
-    if options.n_api:
-        args.append('--n-api')
 
     fs.chdir(path.PROJECT_ROOT)
     code = ex.run_cmd(cmd, args)

--- a/tools/common_py/system/sys_platform.py
+++ b/tools/common_py/system/sys_platform.py
@@ -13,13 +13,17 @@
 # limitations under the License.
 
 import os
+import platform
 import sys
 
 class Platform(object):
     def __init__(self):
         if sys.platform == "win32":
             _os = "windows"
-            _arch = "i686" # TODO: allow x86_64 also
+            if platform.architecture()[0] == "64bit":
+                _arch = "x86_64"
+            else:
+                _arch = "i686"
         else:
             _os, _, _, _, _arch = os.uname()
         self._os = _os

--- a/tools/travis_script.py
+++ b/tools/travis_script.py
@@ -18,7 +18,7 @@ import os
 
 from common_py.system.filesystem import FileSystem as fs
 from common_py.system.executor import Executor as ex
-from common_py.system.platform import Platform
+from common_py.system.sys_platform import Platform
 from check_tidy import check_tidy
 
 platform = Platform()


### PR DESCRIPTION
 * Fixed x64 Windows build
 * Updated libtuv submodule (contains x86_64-windows cmake toolchain files).
 * Removed '--n-api' argument from testrunner.py and used 'iotjs_build_info.js' instead.
 * Enable testrunning on Windows platform on Appveyor CI.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com