### PR TITLE
Fixed 'function declaration is not a prototype' compiler warnings.

### DIFF
--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -125,7 +125,7 @@ JS_FUNCTION(CloseSync) {
   return jerry_create_undefined();
 }
 
-jerry_value_t InitAdc() {
+jerry_value_t InitAdc(void) {
   jerry_value_t jadc_cons = jerry_create_external_function(AdcCons);
   jerry_value_t jprototype = jerry_create_object();
 

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -178,7 +178,7 @@ JS_FUNCTION(BleHciSocketCons) {
 }
 
 
-jerry_value_t InitBlehcisocket() {
+jerry_value_t InitBlehcisocket(void) {
   jerry_value_t jblehcisocketCons =
       jerry_create_external_function(BleHciSocketCons);
 

--- a/src/modules/iotjs_module_crypto.c
+++ b/src/modules/iotjs_module_crypto.c
@@ -530,7 +530,7 @@ JS_FUNCTION(Base64Encode) {
 }
 
 
-jerry_value_t InitCrypto() {
+jerry_value_t InitCrypto(void) {
   jerry_value_t jcrypto = jerry_create_object();
 
   iotjs_jval_set_method(jcrypto, IOTJS_MAGIC_STRING_SHAENCODE, ShaEncode);

--- a/src/modules/iotjs_module_dynamicloader.c
+++ b/src/modules/iotjs_module_dynamicloader.c
@@ -85,6 +85,6 @@ JS_FUNCTION(OpenNativeModule) {
   return exports;
 }
 
-jerry_value_t InitDynamicloader() {
+jerry_value_t InitDynamicloader(void) {
   return jerry_create_external_function(OpenNativeModule);
 }

--- a/src/modules/iotjs_module_gpio.c
+++ b/src/modules/iotjs_module_gpio.c
@@ -282,7 +282,7 @@ JS_FUNCTION(SetDirectionSync) {
   return jerry_create_undefined();
 }
 
-jerry_value_t InitGpio() {
+jerry_value_t InitGpio(void) {
   jerry_value_t jgpioConstructor = jerry_create_external_function(GpioCons);
 
   jerry_value_t jprototype = jerry_create_object();

--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -178,7 +178,7 @@ JS_FUNCTION(ReadSync) {
   return result;
 }
 
-jerry_value_t InitI2c() {
+jerry_value_t InitI2c(void) {
   jerry_value_t ji2c_cons = jerry_create_external_function(I2cCons);
 
   jerry_value_t prototype = jerry_create_object();

--- a/src/modules/iotjs_module_mqtt.c
+++ b/src/modules/iotjs_module_mqtt.c
@@ -840,7 +840,7 @@ JS_FUNCTION(MqttSendAck) {
   return jbuff;
 }
 
-jerry_value_t InitMQTT() {
+jerry_value_t InitMQTT(void) {
   jerry_value_t jMQTT = jerry_create_object();
   iotjs_jval_set_method(jMQTT, IOTJS_MAGIC_STRING_CONNECT, MqttConnect);
   iotjs_jval_set_method(jMQTT, IOTJS_MAGIC_STRING_DISCONNECT, MqttDisconnect);

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -254,7 +254,7 @@ JS_FUNCTION(SetPeriodSync) {
   return pwm_set_period_or_frequency(pwm, jargv, jargc, kPwmOpSetPeriod, false);
 }
 
-jerry_value_t InitPwm() {
+jerry_value_t InitPwm(void) {
   jerry_value_t jpwm_cons = jerry_create_external_function(PwmCons);
 
   jerry_value_t jprototype = jerry_create_object();

--- a/src/modules/iotjs_module_spi.c
+++ b/src/modules/iotjs_module_spi.c
@@ -297,7 +297,7 @@ JS_FUNCTION(CloseSync) {
   return jerry_create_undefined();
 }
 
-jerry_value_t InitSpi() {
+jerry_value_t InitSpi(void) {
   jerry_value_t jspi_cons = jerry_create_external_function(SpiCons);
 
   jerry_value_t prototype = jerry_create_object();

--- a/src/modules/iotjs_module_tls.c
+++ b/src/modules/iotjs_module_tls.c
@@ -623,7 +623,7 @@ JS_FUNCTION(Read) {
 }
 
 
-jerry_value_t InitTls() {
+jerry_value_t InitTls(void) {
   jerry_value_t jtls = jerry_create_object();
 
   iotjs_jval_set_method(jtls, IOTJS_MAGIC_STRING_CONNECT, Connect);

--- a/src/modules/iotjs_module_uart.c
+++ b/src/modules/iotjs_module_uart.c
@@ -243,7 +243,7 @@ JS_FUNCTION(CloseSync) {
   return jerry_create_undefined();
 }
 
-jerry_value_t InitUart() {
+jerry_value_t InitUart(void) {
   jerry_value_t juart_cons = jerry_create_external_function(UartCons);
 
   jerry_value_t prototype = jerry_create_object();

--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -350,7 +350,7 @@ JS_FUNCTION(Unref) {
 }
 
 
-jerry_value_t InitUdp() {
+jerry_value_t InitUdp(void) {
   jerry_value_t udp = jerry_create_external_function(UDP);
 
   jerry_value_t prototype = jerry_create_object();

--- a/src/modules/iotjs_module_websocket.c
+++ b/src/modules/iotjs_module_websocket.c
@@ -776,7 +776,7 @@ JS_FUNCTION(WsPingOrPong) {
 }
 
 
-jerry_value_t InitWebsocket() {
+jerry_value_t InitWebsocket(void) {
   IOTJS_UNUSED(WS_GUID);
   jerry_value_t jws = jerry_create_object();
   iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_CLOSE, WsClose);


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com