### PR TITLE
Unified function and variable names in C source codes.

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -253,7 +253,7 @@ jerry_value_t iotjs_jval_as_function(jerry_value_t jval) {
 }
 
 
-bool iotjs_jval_set_prototype(const jerry_value_t jobj, jerry_value_t jproto) {
+bool iotjs_jval_set_prototype(jerry_value_t jobj, jerry_value_t jproto) {
   jerry_value_t ret = jerry_set_prototype(jobj, jproto);
   bool error_found = jerry_value_is_error(ret);
   jerry_release_value(ret);

--- a/src/modules.json
+++ b/src/modules.json
@@ -24,7 +24,7 @@
       },
       "native_files": ["modules/iotjs_module_adc.c",
                        "modules/iotjs_module_periph_common.c"],
-      "init": "InitAdc",
+      "init": "iotjs_init_adc",
       "js_file": "js/adc.js"
     },
     "assert": {
@@ -104,29 +104,29 @@
         }
       },
       "native_files": ["modules/iotjs_module_blehcisocket.c"],
-      "init": "InitBlehcisocket",
+      "init": "iotjs_init_blehcisocket",
       "js_file": "js/ble_hci_socket.js",
       "require": ["events"]
     },
     "buffer": {
       "native_files": ["modules/iotjs_module_buffer.c"],
-      "init": "InitBuffer",
+      "init": "iotjs_init_buffer",
       "js_file": "js/buffer.js",
       "require": ["util"]
     },
     "console": {
       "native_files": ["modules/iotjs_module_console.c"],
-      "init": "InitConsole",
+      "init": "iotjs_init_console",
       "js_file": "js/console.js",
       "require": ["util"]
     },
     "constants": {
       "native_files": ["modules/iotjs_module_constants.c"],
-      "init": "InitConstants"
+      "init": "iotjs_init_constants"
     },
     "crypto": {
       "native_files": ["modules/iotjs_module_crypto.c"],
-      "init": "InitCrypto",
+      "init": "iotjs_init_crypto",
       "js_file": "js/crypto.js"
     },
     "dgram": {
@@ -135,7 +135,7 @@
     },
     "dns": {
       "native_files": ["modules/iotjs_module_dns.c"],
-      "init": "InitDns",
+      "init": "iotjs_init_dns",
       "js_file": "js/dns.js",
       "require": ["util"]
     },
@@ -145,7 +145,7 @@
     },
     "fs": {
       "native_files": ["modules/iotjs_module_fs.c"],
-      "init": "InitFs",
+      "init": "iotjs_init_fs",
       "js_file": "js/fs.js",
       "require": ["constants", "util"]
     },
@@ -169,7 +169,7 @@
       },
       "native_files": ["modules/iotjs_module_gpio.c",
                        "modules/iotjs_module_periph_common.c"],
-      "init": "InitGpio",
+      "init": "iotjs_init_gpio",
       "js_file": "js/gpio.js"
     },
     "http": {
@@ -203,7 +203,7 @@
     },
     "http_parser": {
       "native_files": ["modules/iotjs_module_http_parser.c"],
-      "init": "InitHttpParser"
+      "init": "iotjs_init_http_parser"
     },
     "https": {
       "js_file": "js/https.js",
@@ -229,7 +229,7 @@
       },
       "native_files": ["modules/iotjs_module_i2c.c",
                        "modules/iotjs_module_periph_common.c"],
-      "init": "InitI2c",
+      "init": "iotjs_init_i2c",
       "js_file": "js/i2c.js"
     },
     "module": {
@@ -240,7 +240,7 @@
       "js_file": "js/mqtt.js",
       "require": ["events", "util", "url"],
       "native_files": ["modules/iotjs_module_mqtt.c"],
-      "init": "InitMQTT"
+      "init": "iotjs_init_mqtt"
     },
     "napi": {
       "native_files": ["modules/iotjs_module_dynamicloader.c",
@@ -253,7 +253,7 @@
                        "napi/node_api_object_wrap.c",
                        "napi/node_api_property.c",
                        "napi/node_api_value.c"],
-      "init": "InitDynamicloader"
+      "init": "iotjs_init_dynamicloader"
     },
     "net": {
       "js_file": "js/net.js",
@@ -261,7 +261,7 @@
     },
     "process": {
       "native_files": ["modules/iotjs_module_process.c"],
-      "init": "InitProcess"
+      "init": "iotjs_init_process"
     },
     "pwm": {
       "platforms": {
@@ -283,7 +283,7 @@
       },
       "native_files": ["modules/iotjs_module_pwm.c",
                        "modules/iotjs_module_periph_common.c"],
-      "init": "InitPwm",
+      "init": "iotjs_init_pwm",
       "js_file": "js/pwm.js"
     },
     "spi": {
@@ -303,7 +303,7 @@
       },
       "native_files": ["modules/iotjs_module_spi.c",
                        "modules/iotjs_module_periph_common.c"],
-      "init": "InitSpi",
+      "init": "iotjs_init_spi",
       "js_file": "js/spi.js"
     },
     "stm32f4dis": {
@@ -313,7 +313,7 @@
         }
       },
       "native_files": ["modules/iotjs_module_stm32f4dis.c"],
-      "init": "InitStm32f4dis"
+      "init": "iotjs_init_stm32f4dis"
     },
     "stm32f7nucleo": {
       "platforms": {
@@ -322,7 +322,7 @@
         }
       },
       "native_files": ["modules/iotjs_module_stm32f7nucleo.c"],
-      "init": "InitStm32f7nucleo"
+      "init": "iotjs_init_stm32f7nucleo"
     },
     "stream": {
       "js_file": "js/stream.js",
@@ -347,17 +347,17 @@
     },
     "tcp": {
       "native_files": ["modules/iotjs_module_tcp.c"],
-      "init": "InitTcp"
+      "init": "iotjs_init_tcp"
     },
     "timers": {
       "native_files": ["modules/iotjs_module_timer.c"],
-      "init": "InitTimer",
+      "init": "iotjs_init_timer",
       "js_file": "js/timers.js",
       "require": ["util"]
     },
     "tls": {
       "native_files": ["modules/iotjs_module_tls.c"],
-      "init": "InitTls",
+      "init": "iotjs_init_tls",
       "js_file": "js/tls.js",
       "cmakefile": "../cmake/mbedtls.cmake",
       "require": ["net", "util"]
@@ -379,13 +379,13 @@
       },
       "native_files": ["modules/iotjs_module_uart.c",
                        "modules/iotjs_module_periph_common.c"],
-      "init": "InitUart",
+      "init": "iotjs_init_uart",
       "js_file": "js/uart.js",
       "require": ["events"]
     },
     "udp": {
       "native_files": ["modules/iotjs_module_udp.c"],
-      "init": "InitUdp"
+      "init": "iotjs_init_udp"
     },
     "util": {
       "js_file": "js/util.js"
@@ -393,13 +393,13 @@
     "websocket": {
       "native_files": ["modules/iotjs_module_websocket.h",
                        "modules/iotjs_module_websocket.c"],
-      "init": "InitWebsocket",
+      "init": "iotjs_init_websocket",
       "js_file": "js/websocket.js",
       "require": ["crypto", "events", "net", "util"]
     },
     "bridge": {
       "native_files": ["modules/iotjs_module_bridge.c"],
-      "init": "InitBridge",
+      "init": "iotjs_init_bridge",
       "js_file": "js/bridge.js"
     },
     "tizen": {
@@ -409,7 +409,7 @@
         }
       },
       "native_files": ["modules/iotjs_module_tizen.c"],
-      "init": "InitTizen",
+      "init": "iotjs_init_tizen",
       "js_file": "js/tizen.js",
       "require": ["bridge", "events", "util"]
     }

--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -47,7 +47,7 @@ static void adc_worker(uv_work_t* work_req) {
   }
 }
 
-JS_FUNCTION(AdcCons) {
+JS_FUNCTION(adc_constructor) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, object);
   DJS_CHECK_ARG_IF_EXIST(1, function);
@@ -84,7 +84,7 @@ JS_FUNCTION(AdcCons) {
 }
 
 
-JS_FUNCTION(Read) {
+JS_FUNCTION(adc_read) {
   JS_DECLARE_THIS_PTR(adc, adc);
   DJS_CHECK_ARG_IF_EXIST(0, function);
 
@@ -94,7 +94,7 @@ JS_FUNCTION(Read) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(ReadSync) {
+JS_FUNCTION(adc_read_sync) {
   JS_DECLARE_THIS_PTR(adc, adc);
 
   if (!iotjs_adc_read(adc)) {
@@ -104,7 +104,7 @@ JS_FUNCTION(ReadSync) {
   return jerry_create_number(adc->value);
 }
 
-JS_FUNCTION(Close) {
+JS_FUNCTION(adc_close) {
   JS_DECLARE_THIS_PTR(adc, adc);
   DJS_CHECK_ARG_IF_EXIST(0, function);
 
@@ -114,7 +114,7 @@ JS_FUNCTION(Close) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(CloseSync) {
+JS_FUNCTION(adc_close_sync) {
   JS_DECLARE_THIS_PTR(adc, adc);
 
   bool ret = iotjs_adc_close(adc);
@@ -125,14 +125,15 @@ JS_FUNCTION(CloseSync) {
   return jerry_create_undefined();
 }
 
-jerry_value_t InitAdc(void) {
-  jerry_value_t jadc_cons = jerry_create_external_function(AdcCons);
+jerry_value_t iotjs_init_adc(void) {
+  jerry_value_t jadc_cons = jerry_create_external_function(adc_constructor);
   jerry_value_t jprototype = jerry_create_object();
 
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_READ, Read);
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_READSYNC, ReadSync);
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSE, Close);
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSESYNC, CloseSync);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_READ, adc_read);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_READSYNC, adc_read_sync);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSE, adc_close);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSESYNC,
+                        adc_close_sync);
 
   iotjs_jval_set_property_jval(jadc_cons, IOTJS_MAGIC_STRING_PROTOTYPE,
                                jprototype);

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -66,7 +66,7 @@ static void iotjs_blehcisocket_destroy(iotjs_blehcisocket_t* blehcisocket) {
 }
 
 
-JS_FUNCTION(Start) {
+JS_FUNCTION(start) {
   JS_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
 
   iotjs_blehcisocket_start(blehcisocket);
@@ -75,7 +75,7 @@ JS_FUNCTION(Start) {
 }
 
 
-JS_FUNCTION(BindRaw) {
+JS_FUNCTION(bind_raw) {
   JS_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
   JS_CHECK(jargc >= 1);
 
@@ -93,7 +93,7 @@ JS_FUNCTION(BindRaw) {
 }
 
 
-JS_FUNCTION(BindUser) {
+JS_FUNCTION(bind_user) {
   JS_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
   DJS_CHECK_ARGS(1, number);
 
@@ -106,7 +106,7 @@ JS_FUNCTION(BindUser) {
 }
 
 
-JS_FUNCTION(BindControl) {
+JS_FUNCTION(bind_control) {
   JS_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
 
   iotjs_blehcisocket_bindControl(blehcisocket);
@@ -115,7 +115,7 @@ JS_FUNCTION(BindControl) {
 }
 
 
-JS_FUNCTION(IsDevUp) {
+JS_FUNCTION(is_dev_up) {
   JS_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
 
   bool ret = iotjs_blehcisocket_isDevUp(blehcisocket);
@@ -124,7 +124,7 @@ JS_FUNCTION(IsDevUp) {
 }
 
 
-JS_FUNCTION(SetFilter) {
+JS_FUNCTION(set_filter) {
   JS_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
   DJS_CHECK_ARGS(1, object);
 
@@ -138,7 +138,7 @@ JS_FUNCTION(SetFilter) {
 }
 
 
-JS_FUNCTION(Stop) {
+JS_FUNCTION(stop) {
   JS_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
 
   iotjs_blehcisocket_stop(blehcisocket);
@@ -147,7 +147,7 @@ JS_FUNCTION(Stop) {
 }
 
 
-JS_FUNCTION(Write) {
+JS_FUNCTION(write) {
   JS_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
   DJS_CHECK_ARGS(1, object);
 
@@ -161,7 +161,7 @@ JS_FUNCTION(Write) {
 }
 
 
-JS_FUNCTION(BleHciSocketCons) {
+JS_FUNCTION(blehcisocket_cons) {
   DJS_CHECK_THIS();
 
   // Create object
@@ -178,20 +178,21 @@ JS_FUNCTION(BleHciSocketCons) {
 }
 
 
-jerry_value_t InitBlehcisocket(void) {
+jerry_value_t iotjs_init_blehcisocket(void) {
   jerry_value_t jblehcisocketCons =
-      jerry_create_external_function(BleHciSocketCons);
+      jerry_create_external_function(blehcisocket_cons);
 
   jerry_value_t prototype = jerry_create_object();
 
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_START, Start);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_BINDRAW, BindRaw);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_BINDUSER, BindUser);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_BINDCONTROL, BindControl);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_ISDEVUP, IsDevUp);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_SETFILTER, SetFilter);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_STOP, Stop);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_WRITE, Write);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_START, start);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_BINDRAW, bind_raw);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_BINDUSER, bind_user);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_BINDCONTROL,
+                        bind_control);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_ISDEVUP, is_dev_up);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_SETFILTER, set_filter);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_STOP, stop);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_WRITE, write);
 
   iotjs_jval_set_property_jval(jblehcisocketCons, IOTJS_MAGIC_STRING_PROTOTYPE,
                                prototype);

--- a/src/modules/iotjs_module_bridge.c
+++ b/src/modules/iotjs_module_bridge.c
@@ -345,7 +345,7 @@ void bridge_worker(uv_work_t* req) {
 /**
  * send async message
  */
-JS_FUNCTION(MessageAsync) {
+JS_FUNCTION(message_async) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(3, string, string, string);
   DJS_CHECK_ARG_IF_EXIST(3, function);
@@ -407,9 +407,9 @@ JS_FUNCTION(MessageAsync) {
 /**
  * Init method called by IoT.js
  */
-jerry_value_t InitBridge() {
-  jerry_value_t messagModule = jerry_create_object();
-  iotjs_jval_set_method(messagModule, "send", MessageAsync);
+jerry_value_t iotjs_init_bridge() {
+  jerry_value_t messag_module = jerry_create_object();
+  iotjs_jval_set_method(messag_module, "send", message_async);
   iotjs_bridge_init();
-  return messagModule;
+  return messag_module;
 }

--- a/src/modules/iotjs_module_console.c
+++ b/src/modules/iotjs_module_console.c
@@ -18,8 +18,8 @@
 
 // This function should be able to print utf8 encoded string
 // as utf8 is internal string representation in Jerryscript
-static jerry_value_t Print(const jerry_value_t* jargv,
-                           const jerry_length_t jargc, FILE* out_fd) {
+static jerry_value_t console_print(const jerry_value_t* jargv,
+                                   const jerry_length_t jargc, FILE* out_fd) {
   JS_CHECK_ARGS(1, string);
   iotjs_string_t msg = JS_GET_ARG(0, string);
   const char* str = iotjs_string_data(&msg);
@@ -44,21 +44,21 @@ static jerry_value_t Print(const jerry_value_t* jargv,
 }
 
 
-JS_FUNCTION(Stdout) {
-  return Print(jargv, jargc, stdout);
+JS_FUNCTION(console_stdout) {
+  return console_print(jargv, jargc, stdout);
 }
 
 
-JS_FUNCTION(Stderr) {
-  return Print(jargv, jargc, stderr);
+JS_FUNCTION(console_stderr) {
+  return console_print(jargv, jargc, stderr);
 }
 
 
-jerry_value_t InitConsole(void) {
+jerry_value_t iotjs_init_console(void) {
   jerry_value_t console = jerry_create_object();
 
-  iotjs_jval_set_method(console, IOTJS_MAGIC_STRING_STDOUT, Stdout);
-  iotjs_jval_set_method(console, IOTJS_MAGIC_STRING_STDERR, Stderr);
+  iotjs_jval_set_method(console, IOTJS_MAGIC_STRING_STDOUT, console_stdout);
+  iotjs_jval_set_method(console, IOTJS_MAGIC_STRING_STDERR, console_stderr);
 
   return console;
 }

--- a/src/modules/iotjs_module_constants.c
+++ b/src/modules/iotjs_module_constants.c
@@ -22,7 +22,7 @@
     iotjs_jval_set_property_number(object, #constant, constant); \
   } while (0)
 
-jerry_value_t InitConstants(void) {
+jerry_value_t iotjs_init_constants(void) {
   jerry_value_t constants = jerry_create_object();
 
   SET_CONSTANT(constants, O_APPEND);

--- a/src/modules/iotjs_module_crypto.c
+++ b/src/modules/iotjs_module_crypto.c
@@ -393,7 +393,7 @@ size_t iotjs_sha256_encode(unsigned char **out_buff,
 #endif /* ENABLE_MODULE_TLS */
 
 
-JS_FUNCTION(ShaEncode) {
+JS_FUNCTION(sha_encode) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(2, any, number);
 
@@ -447,7 +447,7 @@ JS_FUNCTION(ShaEncode) {
 }
 
 
-JS_FUNCTION(RsaVerify) {
+JS_FUNCTION(rsa_verify) {
 #if !ENABLE_MODULE_TLS
   return JS_CREATE_ERROR(COMMON, no_tls_err_str);
 #else  /* ENABLE_MODULE_TLS */
@@ -506,7 +506,7 @@ JS_FUNCTION(RsaVerify) {
 }
 
 
-JS_FUNCTION(Base64Encode) {
+JS_FUNCTION(base64_encode) {
   DJS_CHECK_THIS();
 
   jerry_value_t jstring = JS_GET_ARG(0, any);
@@ -530,12 +530,13 @@ JS_FUNCTION(Base64Encode) {
 }
 
 
-jerry_value_t InitCrypto(void) {
+jerry_value_t iotjs_init_crypto(void) {
   jerry_value_t jcrypto = jerry_create_object();
 
-  iotjs_jval_set_method(jcrypto, IOTJS_MAGIC_STRING_SHAENCODE, ShaEncode);
-  iotjs_jval_set_method(jcrypto, IOTJS_MAGIC_STRING_BASE64ENCODE, Base64Encode);
-  iotjs_jval_set_method(jcrypto, IOTJS_MAGIC_STRING_RSAVERIFY, RsaVerify);
+  iotjs_jval_set_method(jcrypto, IOTJS_MAGIC_STRING_SHAENCODE, sha_encode);
+  iotjs_jval_set_method(jcrypto, IOTJS_MAGIC_STRING_BASE64ENCODE,
+                        base64_encode);
+  iotjs_jval_set_method(jcrypto, IOTJS_MAGIC_STRING_RSAVERIFY, rsa_verify);
 
   return jcrypto;
 }

--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -51,8 +51,8 @@ char* getaddrinfo_error_str(int status) {
   }
 }
 
-static void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status,
-                             struct addrinfo* res) {
+static void after_get_addr_info(uv_getaddrinfo_t* req, int status,
+                                struct addrinfo* res) {
   size_t argc = 0;
   jerry_value_t args[3] = { 0 };
 
@@ -117,7 +117,7 @@ static void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status,
 #endif
 
 
-JS_FUNCTION(GetAddressInfo) {
+JS_FUNCTION(get_address_info) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(4, string, number, number, function);
 
@@ -188,7 +188,7 @@ JS_FUNCTION(GetAddressInfo) {
   hints.ai_flags = flags;
 
   error = uv_getaddrinfo(iotjs_environment_loop(iotjs_environment_get()),
-                         (uv_getaddrinfo_t*)req_addr, AfterGetAddrInfo,
+                         (uv_getaddrinfo_t*)req_addr, after_get_addr_info,
                          iotjs_string_data(&hostname), NULL, &hints);
 
   if (error) {
@@ -209,10 +209,10 @@ JS_FUNCTION(GetAddressInfo) {
   } while (0)
 
 
-jerry_value_t InitDns(void) {
+jerry_value_t iotjs_init_dns(void) {
   jerry_value_t dns = jerry_create_object();
 
-  iotjs_jval_set_method(dns, IOTJS_MAGIC_STRING_GETADDRINFO, GetAddressInfo);
+  iotjs_jval_set_method(dns, IOTJS_MAGIC_STRING_GETADDRINFO, get_address_info);
   SET_CONSTANT(dns, AI_ADDRCONFIG);
   SET_CONSTANT(dns, AI_V4MAPPED);
 

--- a/src/modules/iotjs_module_dynamicloader.c
+++ b/src/modules/iotjs_module_dynamicloader.c
@@ -24,7 +24,7 @@
 #endif
 #include <stdlib.h>
 
-JS_FUNCTION(OpenNativeModule) {
+JS_FUNCTION(open_native_module) {
   iotjs_string_t location = JS_GET_ARG(0, string);
 
 #if _WIN32
@@ -85,6 +85,6 @@ JS_FUNCTION(OpenNativeModule) {
   return exports;
 }
 
-jerry_value_t InitDynamicloader(void) {
-  return jerry_create_external_function(OpenNativeModule);
+jerry_value_t iotjs_init_dynamicloader(void) {
+  return jerry_create_external_function(open_native_module);
 }

--- a/src/modules/iotjs_module_gpio.c
+++ b/src/modules/iotjs_module_gpio.c
@@ -142,7 +142,7 @@ static jerry_value_t gpio_set_configuration(iotjs_gpio_t* gpio,
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(GpioCons) {
+JS_FUNCTION(gpio_constructor) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, object);
   DJS_CHECK_ARG_IF_EXIST(1, function);
@@ -171,7 +171,7 @@ JS_FUNCTION(GpioCons) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(Close) {
+JS_FUNCTION(gpio_close) {
   JS_DECLARE_THIS_PTR(gpio, gpio);
   DJS_CHECK_ARG_IF_EXIST(0, function);
 
@@ -181,7 +181,7 @@ JS_FUNCTION(Close) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(CloseSync) {
+JS_FUNCTION(gpio_close_sync) {
   JS_DECLARE_THIS_PTR(gpio, gpio);
 
   if (!iotjs_gpio_close(gpio)) {
@@ -232,17 +232,17 @@ jerry_value_t gpio_do_write_or_writesync(const jerry_value_t jfunc,
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(Write) {
+JS_FUNCTION(gpio_write) {
   return gpio_do_write_or_writesync(jfunc, jthis, jargv, jargc,
                                     IOTJS_GPIO_WRITE);
 }
 
-JS_FUNCTION(WriteSync) {
+JS_FUNCTION(gpio_write_sync) {
   return gpio_do_write_or_writesync(jfunc, jthis, jargv, jargc,
                                     IOTJS_GPIO_WRITESYNC);
 }
 
-JS_FUNCTION(Read) {
+JS_FUNCTION(gpio_read) {
   JS_DECLARE_THIS_PTR(gpio, gpio);
   DJS_CHECK_ARG_IF_EXIST(0, function);
 
@@ -252,7 +252,7 @@ JS_FUNCTION(Read) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(ReadSync) {
+JS_FUNCTION(gpio_read_sync) {
   JS_DECLARE_THIS_PTR(gpio, gpio);
 
   if (!iotjs_gpio_read(gpio)) {
@@ -262,7 +262,7 @@ JS_FUNCTION(ReadSync) {
   return jerry_create_boolean(gpio->value);
 }
 
-JS_FUNCTION(SetDirectionSync) {
+JS_FUNCTION(gpio_set_direction_sync) {
   DJS_CHECK_ARGS(1, number);
   JS_DECLARE_THIS_PTR(gpio, gpio);
 
@@ -282,21 +282,24 @@ JS_FUNCTION(SetDirectionSync) {
   return jerry_create_undefined();
 }
 
-jerry_value_t InitGpio(void) {
-  jerry_value_t jgpioConstructor = jerry_create_external_function(GpioCons);
+jerry_value_t iotjs_init_gpio(void) {
+  jerry_value_t jgpio_const = jerry_create_external_function(gpio_constructor);
 
   jerry_value_t jprototype = jerry_create_object();
 
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSE, Close);
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSESYNC, CloseSync);
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_WRITE, Write);
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_WRITESYNC, WriteSync);
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_READ, Read);
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_READSYNC, ReadSync);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSE, gpio_close);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSESYNC,
+                        gpio_close_sync);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_WRITE, gpio_write);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_WRITESYNC,
+                        gpio_write_sync);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_READ, gpio_read);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_READSYNC,
+                        gpio_read_sync);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETDIRECTIONSYNC,
-                        SetDirectionSync);
+                        gpio_set_direction_sync);
 
-  iotjs_jval_set_property_jval(jgpioConstructor, IOTJS_MAGIC_STRING_PROTOTYPE,
+  iotjs_jval_set_property_jval(jgpio_const, IOTJS_MAGIC_STRING_PROTOTYPE,
                                jprototype);
   jerry_release_value(jprototype);
 
@@ -306,7 +309,7 @@ jerry_value_t InitGpio(void) {
                                  kGpioDirectionIn);
   iotjs_jval_set_property_number(jdirection, IOTJS_MAGIC_STRING_OUT_U,
                                  kGpioDirectionOut);
-  iotjs_jval_set_property_jval(jgpioConstructor, IOTJS_MAGIC_STRING_DIRECTION_U,
+  iotjs_jval_set_property_jval(jgpio_const, IOTJS_MAGIC_STRING_DIRECTION_U,
                                jdirection);
   jerry_release_value(jdirection);
 
@@ -327,8 +330,7 @@ jerry_value_t InitGpio(void) {
   iotjs_jval_set_property_number(jmode, IOTJS_MAGIC_STRING_OPENDRAIN_U,
                                  kGpioModeOpendrain);
 #endif
-  iotjs_jval_set_property_jval(jgpioConstructor, IOTJS_MAGIC_STRING_MODE_U,
-                               jmode);
+  iotjs_jval_set_property_jval(jgpio_const, IOTJS_MAGIC_STRING_MODE_U, jmode);
   jerry_release_value(jmode);
 
   // GPIO edge properties
@@ -341,9 +343,8 @@ jerry_value_t InitGpio(void) {
                                  kGpioEdgeFalling);
   iotjs_jval_set_property_number(jedge, IOTJS_MAGIC_STRING_BOTH_U,
                                  kGpioEdgeBoth);
-  iotjs_jval_set_property_jval(jgpioConstructor, IOTJS_MAGIC_STRING_EDGE_U,
-                               jedge);
+  iotjs_jval_set_property_jval(jgpio_const, IOTJS_MAGIC_STRING_EDGE_U, jedge);
   jerry_release_value(jedge);
 
-  return jgpioConstructor;
+  return jgpio_const;
 }

--- a/src/modules/iotjs_module_http_parser.c
+++ b/src/modules/iotjs_module_http_parser.c
@@ -375,7 +375,7 @@ static jerry_value_t iotjs_http_parser_return_parserrror(
 }
 
 
-JS_FUNCTION(Finish) {
+JS_FUNCTION(js_func_finish) {
   JS_DECLARE_THIS_PTR(http_parserwrap, parser);
 
   http_parser* nativeparser = &parser->parser;
@@ -389,7 +389,7 @@ JS_FUNCTION(Finish) {
 }
 
 
-JS_FUNCTION(Execute) {
+JS_FUNCTION(js_func_execute) {
   JS_DECLARE_THIS_PTR(http_parserwrap, parser);
   DJS_CHECK_ARGS(1, object);
 
@@ -426,17 +426,17 @@ static jerry_value_t iotjs_http_parser_pause(jerry_value_t jthis, int paused) {
 }
 
 
-JS_FUNCTION(Pause) {
+JS_FUNCTION(js_func_pause) {
   return iotjs_http_parser_pause(jthis, 1);
 }
 
 
-JS_FUNCTION(Resume) {
+JS_FUNCTION(js_func_resume) {
   return iotjs_http_parser_pause(jthis, 0);
 }
 
 
-JS_FUNCTION(HTTPParserCons) {
+JS_FUNCTION(http_parser_cons) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, number);
 
@@ -469,31 +469,31 @@ static void http_parser_register_methods_object(jerry_value_t target) {
   jerry_release_value(methods);
 }
 
-jerry_value_t InitHttpParser(void) {
+jerry_value_t iotjs_init_http_parser(void) {
   jerry_value_t http_parser = jerry_create_object();
 
-  jerry_value_t jParserCons = jerry_create_external_function(HTTPParserCons);
+  jerry_value_t jparser_cons = jerry_create_external_function(http_parser_cons);
   iotjs_jval_set_property_jval(http_parser, IOTJS_MAGIC_STRING_HTTPPARSER,
-                               jParserCons);
+                               jparser_cons);
 
-  iotjs_jval_set_property_number(jParserCons, IOTJS_MAGIC_STRING_REQUEST_U,
+  iotjs_jval_set_property_number(jparser_cons, IOTJS_MAGIC_STRING_REQUEST_U,
                                  HTTP_REQUEST);
-  iotjs_jval_set_property_number(jParserCons, IOTJS_MAGIC_STRING_RESPONSE_U,
+  iotjs_jval_set_property_number(jparser_cons, IOTJS_MAGIC_STRING_RESPONSE_U,
                                  HTTP_RESPONSE);
 
-  http_parser_register_methods_object(jParserCons);
+  http_parser_register_methods_object(jparser_cons);
 
   jerry_value_t prototype = jerry_create_object();
 
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_EXECUTE, Execute);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_FINISH, Finish);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_PAUSE, Pause);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_RESUME, Resume);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_EXECUTE, js_func_execute);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_FINISH, js_func_finish);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_PAUSE, js_func_pause);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_RESUME, js_func_resume);
 
-  iotjs_jval_set_property_jval(jParserCons, IOTJS_MAGIC_STRING_PROTOTYPE,
+  iotjs_jval_set_property_jval(jparser_cons, IOTJS_MAGIC_STRING_PROTOTYPE,
                                prototype);
 
-  jerry_release_value(jParserCons);
+  jerry_release_value(jparser_cons);
   jerry_release_value(prototype);
 
   return http_parser;

--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -51,7 +51,7 @@ static void i2c_worker(uv_work_t* work_req) {
   }
 }
 
-JS_FUNCTION(I2cCons) {
+JS_FUNCTION(i2c_constructor) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, object);
   DJS_CHECK_ARG_IF_EXIST(1, function);
@@ -84,7 +84,7 @@ JS_FUNCTION(I2cCons) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(Close) {
+JS_FUNCTION(i2c_close) {
   JS_DECLARE_THIS_PTR(i2c, i2c);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
@@ -94,7 +94,7 @@ JS_FUNCTION(Close) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(CloseSync) {
+JS_FUNCTION(i2c_close_sync) {
   JS_DECLARE_THIS_PTR(i2c, i2c);
 
   if (!iotjs_i2c_close(i2c)) {
@@ -104,8 +104,9 @@ JS_FUNCTION(CloseSync) {
   return jerry_create_undefined();
 }
 
-static jerry_value_t i2c_write(iotjs_i2c_t* i2c, const jerry_value_t jargv[],
-                               const jerry_length_t jargc, bool async) {
+static jerry_value_t i2c_write_helper(iotjs_i2c_t* i2c,
+                                      const jerry_value_t jargv[],
+                                      const jerry_length_t jargc, bool async) {
   jerry_value_t jarray;
   JS_GET_REQUIRED_ARG_VALUE(0, jarray, IOTJS_MAGIC_STRING_DATA, array);
 
@@ -128,26 +129,26 @@ static jerry_value_t i2c_write(iotjs_i2c_t* i2c, const jerry_value_t jargv[],
 
 typedef enum { IOTJS_I2C_WRITE, IOTJS_I2C_WRITESYNC } iotjs_i2c_op_t;
 
-jerry_value_t i2c_do_write_or_writesync(const jerry_value_t jfunc,
-                                        const jerry_value_t jthis,
-                                        const jerry_value_t jargv[],
-                                        const jerry_length_t jargc,
-                                        const iotjs_i2c_op_t i2c_op) {
+static jerry_value_t i2c_do_write_or_writesync(const jerry_value_t jfunc,
+                                               const jerry_value_t jthis,
+                                               const jerry_value_t jargv[],
+                                               const jerry_length_t jargc,
+                                               const iotjs_i2c_op_t i2c_op) {
   JS_DECLARE_THIS_PTR(i2c, i2c);
   DJS_CHECK_ARGS(1, array);
-  return i2c_write(i2c, jargv, jargc, i2c_op == IOTJS_I2C_WRITE);
+  return i2c_write_helper(i2c, jargv, jargc, i2c_op == IOTJS_I2C_WRITE);
 }
 
-JS_FUNCTION(Write) {
+JS_FUNCTION(i2c_write) {
   return i2c_do_write_or_writesync(jfunc, jthis, jargv, jargc, IOTJS_I2C_WRITE);
 }
 
-JS_FUNCTION(WriteSync) {
+JS_FUNCTION(i2c_write_sync) {
   return i2c_do_write_or_writesync(jfunc, jthis, jargv, jargc,
                                    IOTJS_I2C_WRITESYNC);
 }
 
-JS_FUNCTION(Read) {
+JS_FUNCTION(i2c_read) {
   JS_DECLARE_THIS_PTR(i2c, i2c);
   DJS_CHECK_ARGS(1, number);
   DJS_CHECK_ARG_IF_EXIST(1, function);
@@ -160,7 +161,7 @@ JS_FUNCTION(Read) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(ReadSync) {
+JS_FUNCTION(i2c_read_sync) {
   JS_DECLARE_THIS_PTR(i2c, i2c);
   DJS_CHECK_ARGS(1, number);
 
@@ -178,17 +179,19 @@ JS_FUNCTION(ReadSync) {
   return result;
 }
 
-jerry_value_t InitI2c(void) {
-  jerry_value_t ji2c_cons = jerry_create_external_function(I2cCons);
+jerry_value_t iotjs_init_i2c(void) {
+  jerry_value_t ji2c_cons = jerry_create_external_function(i2c_constructor);
 
   jerry_value_t prototype = jerry_create_object();
 
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSE, Close);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSESYNC, CloseSync);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_WRITE, Write);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_WRITESYNC, WriteSync);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_READ, Read);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_READSYNC, ReadSync);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSE, i2c_close);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSESYNC,
+                        i2c_close_sync);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_WRITE, i2c_write);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_WRITESYNC,
+                        i2c_write_sync);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_READ, i2c_read);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_READSYNC, i2c_read_sync);
 
   iotjs_jval_set_property_jval(ji2c_cons, IOTJS_MAGIC_STRING_PROTOTYPE,
                                prototype);

--- a/src/modules/iotjs_module_mqtt.h
+++ b/src/modules/iotjs_module_mqtt.h
@@ -97,7 +97,7 @@ typedef union {
     uint8_t dup : 1;
     uint8_t type : 4;
   } bits;
-} MQTTHeader;
+} mqtt_header_t;
 
 enum {
   // Reserved bit, must be 0

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -74,7 +74,7 @@ static jerry_value_t pwm_set_configuration(iotjs_pwm_t* pwm,
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(PwmCons) {
+JS_FUNCTION(pwm_constructor) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, object);
   DJS_CHECK_ARG_IF_EXIST(1, function);
@@ -111,7 +111,7 @@ JS_FUNCTION(PwmCons) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(Close) {
+JS_FUNCTION(pwm_close) {
   JS_DECLARE_THIS_PTR(pwm, pwm);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
@@ -121,7 +121,7 @@ JS_FUNCTION(Close) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(CloseSync) {
+JS_FUNCTION(pwm_close_sync) {
   JS_DECLARE_THIS_PTR(pwm, pwm);
 
   if (!iotjs_pwm_close(pwm)) {
@@ -131,7 +131,7 @@ JS_FUNCTION(CloseSync) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(SetDutyCycle) {
+JS_FUNCTION(pwm_set_duty_cycle) {
   JS_DECLARE_THIS_PTR(pwm, pwm);
   DJS_CHECK_ARGS(1, number);
   DJS_CHECK_ARG_IF_EXIST(1, function);
@@ -148,7 +148,7 @@ JS_FUNCTION(SetDutyCycle) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(SetDutyCycleSync) {
+JS_FUNCTION(pwm_set_duty_cycle_sync) {
   JS_DECLARE_THIS_PTR(pwm, pwm);
   DJS_CHECK_ARGS(1, number);
 
@@ -164,7 +164,7 @@ JS_FUNCTION(SetDutyCycleSync) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(SetEnable) {
+JS_FUNCTION(pwm_set_enable) {
   JS_DECLARE_THIS_PTR(pwm, pwm);
   DJS_CHECK_ARGS(1, boolean);
   DJS_CHECK_ARG_IF_EXIST(1, function);
@@ -178,7 +178,7 @@ JS_FUNCTION(SetEnable) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(SetEnableSync) {
+JS_FUNCTION(pwm_set_enable_sync) {
   JS_DECLARE_THIS_PTR(pwm, pwm);
   DJS_CHECK_ARGS(1, boolean);
 
@@ -222,7 +222,7 @@ static jerry_value_t pwm_set_period_or_frequency(iotjs_pwm_t* pwm,
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(SetFrequency) {
+JS_FUNCTION(pwm_set_frequency) {
   JS_DECLARE_THIS_PTR(pwm, pwm);
   DJS_CHECK_ARGS(1, number);
   DJS_CHECK_ARG_IF_EXIST(1, function);
@@ -231,7 +231,7 @@ JS_FUNCTION(SetFrequency) {
                                      true);
 }
 
-JS_FUNCTION(SetFrequencySync) {
+JS_FUNCTION(pwm_set_frequency_sync) {
   JS_DECLARE_THIS_PTR(pwm, pwm);
   DJS_CHECK_ARGS(1, number);
 
@@ -239,7 +239,7 @@ JS_FUNCTION(SetFrequencySync) {
                                      false);
 }
 
-JS_FUNCTION(SetPeriod) {
+JS_FUNCTION(pwm_set_period) {
   JS_DECLARE_THIS_PTR(pwm, pwm);
   DJS_CHECK_ARGS(1, number);
   DJS_CHECK_ARG_IF_EXIST(1, function);
@@ -247,34 +247,37 @@ JS_FUNCTION(SetPeriod) {
   return pwm_set_period_or_frequency(pwm, jargv, jargc, kPwmOpSetPeriod, true);
 }
 
-JS_FUNCTION(SetPeriodSync) {
+JS_FUNCTION(pwm_set_period_sync) {
   JS_DECLARE_THIS_PTR(pwm, pwm);
   DJS_CHECK_ARGS(1, number);
 
   return pwm_set_period_or_frequency(pwm, jargv, jargc, kPwmOpSetPeriod, false);
 }
 
-jerry_value_t InitPwm(void) {
-  jerry_value_t jpwm_cons = jerry_create_external_function(PwmCons);
+jerry_value_t iotjs_init_pwm(void) {
+  jerry_value_t jpwm_cons = jerry_create_external_function(pwm_constructor);
 
   jerry_value_t jprototype = jerry_create_object();
 
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSE, Close);
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSESYNC, CloseSync);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSE, pwm_close);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_CLOSESYNC,
+                        pwm_close_sync);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETDUTYCYCLE,
-                        SetDutyCycle);
+                        pwm_set_duty_cycle);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETDUTYCYCLESYNC,
-                        SetDutyCycleSync);
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETENABLE, SetEnable);
+                        pwm_set_duty_cycle_sync);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETENABLE,
+                        pwm_set_enable);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETENABLESYNC,
-                        SetEnableSync);
+                        pwm_set_enable_sync);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETFREQUENCY,
-                        SetFrequency);
+                        pwm_set_frequency);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETFREQUENCYSYNC,
-                        SetFrequencySync);
-  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETPERIOD, SetPeriod);
+                        pwm_set_frequency_sync);
+  iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETPERIOD,
+                        pwm_set_period);
   iotjs_jval_set_method(jprototype, IOTJS_MAGIC_STRING_SETPERIODSYNC,
-                        SetPeriodSync);
+                        pwm_set_period_sync);
 
   iotjs_jval_set_property_jval(jpwm_cons, IOTJS_MAGIC_STRING_PROTOTYPE,
                                jprototype);

--- a/src/modules/iotjs_module_spi.c
+++ b/src/modules/iotjs_module_spi.c
@@ -187,7 +187,7 @@ static void spi_worker(uv_work_t* work_req) {
   }
 }
 
-JS_FUNCTION(SpiCons) {
+JS_FUNCTION(spi_constructor) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, object);
   DJS_CHECK_ARG_IF_EXIST(1, function);
@@ -245,7 +245,7 @@ static uint8_t spi_transfer_helper(jerry_value_t jtx_buf, iotjs_spi_t* spi) {
 }
 
 // FIXME: do not need transferArray if array buffer is implemented.
-JS_FUNCTION(Transfer) {
+JS_FUNCTION(spi_transfer) {
   JS_DECLARE_THIS_PTR(spi, spi);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
@@ -256,7 +256,7 @@ JS_FUNCTION(Transfer) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(TransferSync) {
+JS_FUNCTION(spi_transfer_sync) {
   JS_DECLARE_THIS_PTR(spi, spi);
 
   uint8_t op = spi_transfer_helper(jargv[0], spi);
@@ -277,7 +277,7 @@ JS_FUNCTION(TransferSync) {
   return result;
 }
 
-JS_FUNCTION(Close) {
+JS_FUNCTION(spi_close) {
   JS_DECLARE_THIS_PTR(spi, spi);
   DJS_CHECK_ARG_IF_EXIST(1, function);
 
@@ -287,7 +287,7 @@ JS_FUNCTION(Close) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(CloseSync) {
+JS_FUNCTION(spi_close_sync) {
   JS_DECLARE_THIS_PTR(spi, spi);
 
   if (!iotjs_spi_close(spi)) {
@@ -297,15 +297,16 @@ JS_FUNCTION(CloseSync) {
   return jerry_create_undefined();
 }
 
-jerry_value_t InitSpi(void) {
-  jerry_value_t jspi_cons = jerry_create_external_function(SpiCons);
+jerry_value_t iotjs_init_spi(void) {
+  jerry_value_t jspi_cons = jerry_create_external_function(spi_constructor);
 
   jerry_value_t prototype = jerry_create_object();
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSE, Close);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSESYNC, CloseSync);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_TRANSFER, Transfer);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSE, spi_close);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSESYNC,
+                        spi_close_sync);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_TRANSFER, spi_transfer);
   iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_TRANSFERSYNC,
-                        TransferSync);
+                        spi_transfer_sync);
 
   iotjs_jval_set_property_jval(jspi_cons, IOTJS_MAGIC_STRING_PROTOTYPE,
                                prototype);

--- a/src/modules/iotjs_module_stm32f4dis.c
+++ b/src/modules/iotjs_module_stm32f4dis.c
@@ -17,7 +17,7 @@
 #include "iotjs_module_stm32f4dis.h"
 
 
-jerry_value_t InitStm32f4dis() {
+jerry_value_t iotjs_init_stm32f4dis() {
   jerry_value_t stm32f4dis = jerry_create_object();
 
 #if defined(__NUTTX__)

--- a/src/modules/iotjs_module_stm32f7nucleo.c
+++ b/src/modules/iotjs_module_stm32f7nucleo.c
@@ -17,7 +17,7 @@
 #include "iotjs_module_stm32f7nucleo.h"
 
 
-jerry_value_t InitStm32f7nucleo() {
+jerry_value_t iotjs_init_stm32f7nucleo() {
   jerry_value_t stm32f7nucleo = jerry_create_object();
   /* Hardware support in progress, do initialization here */
 

--- a/src/modules/iotjs_module_tcp.h
+++ b/src/modules/iotjs_module_tcp.h
@@ -27,7 +27,7 @@ typedef struct sockaddr_in6 sockaddr_in6;
 typedef struct sockaddr_storage sockaddr_storage;
 
 
-void AddressToJS(jerry_value_t obj, const sockaddr* addr);
+void address_to_js(jerry_value_t obj, const sockaddr* addr);
 
 
 #endif /* IOTJS_MODULE_TCP_H */

--- a/src/modules/iotjs_module_timer.c
+++ b/src/modules/iotjs_module_timer.c
@@ -29,7 +29,7 @@ void iotjs_timer_object_init(jerry_value_t jtimer) {
 }
 
 
-static void TimeoutHandler(uv_timer_t* handle) {
+static void timeout_handler(uv_timer_t* handle) {
   IOTJS_ASSERT(handle != NULL);
 
   jerry_value_t jobject = IOTJS_UV_HANDLE_DATA(handle)->jobject;
@@ -40,7 +40,7 @@ static void TimeoutHandler(uv_timer_t* handle) {
 }
 
 
-JS_FUNCTION(Start) {
+JS_FUNCTION(timer_start) {
   // Check parameters.
   JS_DECLARE_PTR(jthis, uv_timer_t, timer_handle);
   DJS_CHECK_ARGS(2, number, number);
@@ -50,13 +50,13 @@ JS_FUNCTION(Start) {
   uint64_t repeat = JS_GET_ARG(1, number);
 
   // Start timer.
-  int res = uv_timer_start(timer_handle, TimeoutHandler, timeout, repeat);
+  int res = uv_timer_start(timer_handle, timeout_handler, timeout, repeat);
 
   return jerry_create_number(res);
 }
 
 
-JS_FUNCTION(Stop) {
+JS_FUNCTION(timer_stop) {
   JS_DECLARE_PTR(jthis, uv_handle_t, timer_handle);
   // Stop timer.
 
@@ -68,7 +68,7 @@ JS_FUNCTION(Stop) {
 }
 
 
-JS_FUNCTION(Timer) {
+JS_FUNCTION(timer_constructor) {
   JS_CHECK_THIS();
 
   const jerry_value_t jtimer = JS_GET_THIS();
@@ -78,14 +78,14 @@ JS_FUNCTION(Timer) {
 }
 
 
-jerry_value_t InitTimer(void) {
-  jerry_value_t timer = jerry_create_external_function(Timer);
+jerry_value_t iotjs_init_timer(void) {
+  jerry_value_t timer = jerry_create_external_function(timer_constructor);
 
   jerry_value_t prototype = jerry_create_object();
   iotjs_jval_set_property_jval(timer, IOTJS_MAGIC_STRING_PROTOTYPE, prototype);
 
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_START, Start);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_STOP, Stop);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_START, timer_start);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_STOP, timer_stop);
 
   jerry_release_value(prototype);
 

--- a/src/modules/iotjs_module_tizen.c
+++ b/src/modules/iotjs_module_tizen.c
@@ -22,7 +22,7 @@ extern void iotjs_tizen_func(const char* command, const char* message,
 /**
  * Init method called by IoT.js
  */
-jerry_value_t InitTizen() {
+jerry_value_t iotjs_init_tizen() {
   char* module_name = IOTJS_MAGIC_STRING_TIZEN;
   jerry_value_t mymodule = jerry_create_object();
   iotjs_jval_set_property_string_raw(mymodule, IOTJS_MAGIC_STRING_MODULE_NAME,

--- a/src/modules/iotjs_module_tls.c
+++ b/src/modules/iotjs_module_tls.c
@@ -188,7 +188,7 @@ static int iotjs_bio_net_receive(void *ctx, unsigned char *buf, size_t len) {
 }
 
 
-JS_FUNCTION(TlsContext) {
+JS_FUNCTION(tls_tlscontext) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, object);
 
@@ -285,7 +285,7 @@ JS_FUNCTION(TlsContext) {
 }
 
 
-JS_FUNCTION(TlsInit) {
+JS_FUNCTION(tls_init) {
   DJS_CHECK_ARGS(3, object, object, object);
 
   jerry_value_t jtls_socket = JS_GET_ARG(0, object);
@@ -360,7 +360,7 @@ JS_FUNCTION(TlsInit) {
 }
 
 
-JS_FUNCTION(Connect) {
+JS_FUNCTION(tls_connect) {
   JS_DECLARE_THIS_PTR(tls, tls_data);
   DJS_CHECK_ARGS(1, string);
 
@@ -413,7 +413,7 @@ static void iotjs_tls_notify_error(iotjs_tls_t *tls_data) {
 }
 
 
-JS_FUNCTION(Write) {
+JS_FUNCTION(tls_write) {
   JS_DECLARE_THIS_PTR(tls, tls_data);
 
   if (tls_data->state != TLS_CONNECTED) {
@@ -524,7 +524,7 @@ static void tls_handshake(iotjs_tls_t *tls_data, jerry_value_t jthis) {
 }
 
 
-JS_FUNCTION(Read) {
+JS_FUNCTION(tls_read) {
   JS_DECLARE_THIS_PTR(tls, tls_data);
 
   if (tls_data->state == TLS_CLOSED) {
@@ -623,14 +623,14 @@ JS_FUNCTION(Read) {
 }
 
 
-jerry_value_t InitTls(void) {
+jerry_value_t iotjs_init_tls(void) {
   jerry_value_t jtls = jerry_create_object();
 
-  iotjs_jval_set_method(jtls, IOTJS_MAGIC_STRING_CONNECT, Connect);
-  iotjs_jval_set_method(jtls, IOTJS_MAGIC_STRING_READ, Read);
-  iotjs_jval_set_method(jtls, IOTJS_MAGIC_STRING_TLSCONTEXT, TlsContext);
-  iotjs_jval_set_method(jtls, IOTJS_MAGIC_STRING_TLSINIT, TlsInit);
-  iotjs_jval_set_method(jtls, IOTJS_MAGIC_STRING_WRITE, Write);
+  iotjs_jval_set_method(jtls, IOTJS_MAGIC_STRING_CONNECT, tls_connect);
+  iotjs_jval_set_method(jtls, IOTJS_MAGIC_STRING_READ, tls_read);
+  iotjs_jval_set_method(jtls, IOTJS_MAGIC_STRING_TLSCONTEXT, tls_tlscontext);
+  iotjs_jval_set_method(jtls, IOTJS_MAGIC_STRING_TLSINIT, tls_init);
+  iotjs_jval_set_method(jtls, IOTJS_MAGIC_STRING_WRITE, tls_write);
 
   return jtls;
 }

--- a/src/modules/iotjs_module_uart.c
+++ b/src/modules/iotjs_module_uart.c
@@ -145,7 +145,7 @@ static jerry_value_t uart_set_configuration(iotjs_uart_t* uart,
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(UartCons) {
+JS_FUNCTION(uart_constructor) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, object);
   DJS_CHECK_ARG_IF_EXIST(1, function);
@@ -191,7 +191,7 @@ JS_FUNCTION(UartCons) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(Write) {
+JS_FUNCTION(uart_write) {
   JS_DECLARE_PTR(jthis, uv_poll_t, uart_poll_handle);
   DJS_CHECK_ARGS(1, string);
   DJS_CHECK_ARG_IF_EXIST(1, function);
@@ -207,7 +207,7 @@ JS_FUNCTION(Write) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(WriteSync) {
+JS_FUNCTION(uart_write_sync) {
   JS_DECLARE_PTR(jthis, uv_handle_t, uart_poll_handle);
   DJS_CHECK_ARGS(1, string);
 
@@ -226,7 +226,7 @@ JS_FUNCTION(WriteSync) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(Close) {
+JS_FUNCTION(uart_close) {
   JS_DECLARE_PTR(jthis, uv_poll_t, uart_poll_handle);
   DJS_CHECK_ARG_IF_EXIST(0, function);
 
@@ -236,21 +236,23 @@ JS_FUNCTION(Close) {
   return jerry_create_undefined();
 }
 
-JS_FUNCTION(CloseSync) {
+JS_FUNCTION(uart_close_sync) {
   JS_DECLARE_PTR(jthis, uv_handle_t, uart_poll_handle);
 
   iotjs_uv_handle_close(uart_poll_handle, iotjs_uart_handle_close_cb);
   return jerry_create_undefined();
 }
 
-jerry_value_t InitUart(void) {
-  jerry_value_t juart_cons = jerry_create_external_function(UartCons);
+jerry_value_t iotjs_init_uart(void) {
+  jerry_value_t juart_cons = jerry_create_external_function(uart_constructor);
 
   jerry_value_t prototype = jerry_create_object();
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_WRITE, Write);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_WRITESYNC, WriteSync);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSE, Close);
-  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSESYNC, CloseSync);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_WRITE, uart_write);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_WRITESYNC,
+                        uart_write_sync);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSE, uart_close);
+  iotjs_jval_set_method(prototype, IOTJS_MAGIC_STRING_CLOSESYNC,
+                        uart_close_sync);
 
   iotjs_jval_set_property_jval(juart_cons, IOTJS_MAGIC_STRING_PROTOTYPE,
                                prototype);

--- a/src/modules/iotjs_module_websocket.c
+++ b/src/modules/iotjs_module_websocket.c
@@ -281,7 +281,7 @@ static jerry_value_t iotjs_websocket_check_error(uint8_t code) {
 }
 
 
-JS_FUNCTION(PrepareHandshakeRequest) {
+JS_FUNCTION(prepare_handshake_request) {
   DJS_CHECK_THIS();
 
   jerry_value_t jsref = JS_GET_ARG(0, object);
@@ -341,7 +341,7 @@ JS_FUNCTION(PrepareHandshakeRequest) {
  * Connection: Upgrade
  * Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
  */
-JS_FUNCTION(ReceiveHandshakeData) {
+JS_FUNCTION(receive_handshake_data) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(1, string);
 
@@ -370,7 +370,7 @@ JS_FUNCTION(ReceiveHandshakeData) {
   return jfinal;
 }
 
-JS_FUNCTION(ParseHandshakeData) {
+JS_FUNCTION(parse_handshake_data) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(2, object, object);
 
@@ -546,7 +546,7 @@ static uint8_t iotjs_websocket_decode_frame(iotjs_wsclient_t *wsclient,
 }
 
 
-JS_FUNCTION(WsReceive) {
+JS_FUNCTION(ws_receive) {
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(3, object, object, object);
 
@@ -660,7 +660,7 @@ JS_FUNCTION(WsReceive) {
 }
 
 
-JS_FUNCTION(WsInit) {
+JS_FUNCTION(ws_init) {
   DJS_CHECK_THIS();
 
   const jerry_value_t jws = JS_GET_ARG(0, object);
@@ -678,7 +678,7 @@ JS_FUNCTION(WsInit) {
 }
 
 
-JS_FUNCTION(WsClose) {
+JS_FUNCTION(ws_close) {
   DJS_CHECK_THIS();
 
   bool masked = false;
@@ -724,7 +724,7 @@ JS_FUNCTION(WsClose) {
 }
 
 
-JS_FUNCTION(WsSendData) {
+JS_FUNCTION(ws_send_data) {
   DJS_CHECK_THIS();
 
   jerry_value_t jmsg = JS_GET_ARG(0, any);
@@ -750,7 +750,7 @@ JS_FUNCTION(WsSendData) {
 }
 
 
-JS_FUNCTION(WsPingOrPong) {
+JS_FUNCTION(ws_ping_or_pong) {
   DJS_CHECK_THIS();
 
   uint8_t opcode =
@@ -776,20 +776,21 @@ JS_FUNCTION(WsPingOrPong) {
 }
 
 
-jerry_value_t InitWebsocket(void) {
+jerry_value_t iotjs_init_websocket(void) {
   IOTJS_UNUSED(WS_GUID);
+
   jerry_value_t jws = jerry_create_object();
-  iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_CLOSE, WsClose);
+  iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_CLOSE, ws_close);
   iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_PARSEHANDSHAKEDATA,
-                        ParseHandshakeData);
-  iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_PING, WsPingOrPong);
+                        parse_handshake_data);
+  iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_PING, ws_ping_or_pong);
   iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_PREPAREHANDSHAKE,
-                        PrepareHandshakeRequest);
-  iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_SEND, WsSendData);
-  iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_WSINIT, WsInit);
-  iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_WSRECEIVE, WsReceive);
+                        prepare_handshake_request);
+  iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_SEND, ws_send_data);
+  iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_WSINIT, ws_init);
+  iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_WSRECEIVE, ws_receive);
   iotjs_jval_set_method(jws, IOTJS_MAGIC_STRING_WSRECEIVEHANDSHAKEDATA,
-                        ReceiveHandshakeData);
+                        receive_handshake_data);
 
   return jws;
 }


### PR DESCRIPTION
'CamelCase' and 'underscore_case' were mixed together, but
'unerscores_case' should be used always for function and
variable names in the C codes. Most of the exiting code path
used underscores. This patch fixes the remained wrong cases.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com