### PR TITLE
Minor test fixes

### DIFF
--- a/test/run_pass/test_gpio_api.js
+++ b/test/run_pass/test_gpio_api.js
@@ -250,7 +250,7 @@ pin.write({}, function(err) {
 
 var async_pin1 = gpio.open(
   {
-    pin: 0,
+    pin: 20,
     direction: gpio.DIRECTION.OUT
   },
   function(err, async_pin2) {
@@ -270,7 +270,7 @@ var async_pin1 = gpio.open(
 
 gpio.open(
   {
-    pin: 0,
+    pin: 21,
     direction: gpio.DIRECTION.IN
   },
   function(err, async_pin) {
@@ -285,7 +285,7 @@ gpio.open(
 );
 
 gpio.open(
-  { pin: 0 },
+  { pin: 22 },
   function(err, async_pin) {
     open_cb3 = true;
     assert.assert(err === null, 'gpio.open failed: ' + err);

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -391,7 +391,7 @@
     {
       "name": "test_gpio_api.js",
       "skip": [
-        "linux", "nuttx", "tizen", "tizenrt"
+        "linux", "nuttx", "tizen", "tizenrt", "windows"
       ],
       "reason": "need to setup test environment",
       "required-modules": [
@@ -421,7 +421,7 @@
     {
       "name": "test_gpio_output.js",
       "skip": [
-        "linux", "nuttx", "tizen", "tizenrt"
+        "linux", "nuttx", "tizen", "tizenrt", "windows"
       ],
       "reason": "need to setup test environment",
       "required-modules": [
@@ -437,7 +437,7 @@
     {
       "name": "test_i2c_api.js",
       "skip": [
-        "linux", "nuttx", "tizen", "tizenrt"
+        "linux", "nuttx", "tizen", "tizenrt", "windows"
       ],
       "reason": "need to setup test environment",
       "required-modules": [
@@ -763,7 +763,7 @@
     {
       "name": "test_pwm_api.js",
       "skip": [
-        "linux", "nuttx", "tizen", "tizenrt"
+        "linux", "nuttx", "tizen", "tizenrt", "windows"
       ],
       "reason": "need to setup test environment",
       "required-modules": [
@@ -773,7 +773,7 @@
     {
       "name": "test_pwm_async.js",
       "skip": [
-        "all"
+        "linux", "nuttx", "tizen", "tizenrt", "windows"
       ],
       "reason": "need to setup test environment",
       "required-modules": [
@@ -783,7 +783,7 @@
     {
       "name": "test_pwm_sync.js",
       "skip": [
-        "all"
+        "linux", "nuttx", "tizen", "tizenrt", "windows"
       ],
       "reason": "need to setup test environment",
       "required-modules": [


### PR DESCRIPTION
 * Fixed GPIO API tests on linux by changing conflicting pin numbers.
 * Added missing 'windows' target to skip list where it was necessary.
 * Enabled sync and async PWM tests on Mock Linux.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com