### PR TITLE
nuttx: Enable SystemIO also for stm32f7nucleo

### DIFF
--- a/src/platform/nuttx/iotjs_systemio-nuttx.c
+++ b/src/platform/nuttx/iotjs_systemio-nuttx.c
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-#if defined(__NUTTX__) && TARGET_BOARD == stm32f4dis
+#if defined(__NUTTX__) && \
+    (TARGET_BOARD == stm32f4dis || TARGET_BOARD == stm32f7nucleo)
 
 #include <stdint.h>
 


### PR DESCRIPTION
There is nothing specific to stm32f4dis in this file.

It was also tested on Nucleo-f767ZI board.

Relate-to: https://github.com/rzr/webthing-iotjs/issues/3
Change-Id: Ia211acbf8ae1bc8d6d04a33a64e53f476e3fdff8
IoT.js-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com