### PR TITLE
nuttx: Register PWM device only if device file is not present

### DIFF
--- a/src/modules/nuttx/iotjs_module_pwm-nuttx.c
+++ b/src/modules/nuttx/iotjs_module_pwm-nuttx.c
@@ -89,13 +89,15 @@ bool iotjs_pwm_open(iotjs_pwm_t* pwm) {
     return false;
   }
 
-  struct pwm_lowerhalf_s* pwm_lowerhalf =
-      iotjs_pwm_config_nuttx(timer, pwm->pin);
+  if (access(path, F_OK) != 0) {
+    struct pwm_lowerhalf_s* pwm_lowerhalf =
+        iotjs_pwm_config_nuttx(timer, pwm->pin);
 
-  DDDLOG("%s - path: %s, timer: %d\n", __func__, path, timer);
+    DDDLOG("%s - path: %s, timer: %d\n", __func__, path, timer);
 
-  if (pwm_register(path, pwm_lowerhalf) != 0) {
-    return false;
+    if (pwm_register(path, pwm_lowerhalf) != 0) {
+      return false;
+    }
   }
 
   // File open


### PR DESCRIPTION
If configured from menuconfig, device inode is already there
there is no need to register it again.

It was observed on STM32F7 using a config with those options:

```
CONFIG_STM32F7_TIM1=y
CONFIG_STM32F7_TIM1_PWM=y
```

Relate-to: https://github.com/rzr/webthing-iotjs/issues/3
Forwarded: https://github.com/pando-project/iotjs/pull/
Change-Id: I6134f15ead43babe3e5de6a9f0d185f6629f62d2
IoT.js-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com