### PR TITLE
nuttx: Use unix convention for number for PWM file

### DIFF
--- a/src/modules/nuttx/iotjs_module_pwm-nuttx.c
+++ b/src/modules/nuttx/iotjs_module_pwm-nuttx.c
@@ -85,7 +85,7 @@ bool iotjs_pwm_open(iotjs_pwm_t* pwm) {
   char path[PWM_DEVICE_PATH_BUFFER_SIZE] = { 0 };
 
   if (snprintf(path, PWM_DEVICE_PATH_BUFFER_SIZE, PWM_DEVICE_PATH_FORMAT,
-               timer) < 0) {
+               (timer - 1)) < 0) {
     return false;
   }
 


### PR DESCRIPTION
Pre UNIX convention devices start on 0 index while STM32 timers start on 1.
So a -1 shift is applied:

eg: /dev/pwm0 is for used Timer1

It was tested along nucleo-144 (stm32f7) port

Relate-to: https://bitbucket.org/nuttx/nuttx/pull-requests/874/
Relate-to: https://github.com/rzr/webthing-iotjs/issues/3
Change-Id: Ia0b468bcb203f94107e472f837a5d38dbcfee71d
IoT.js-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com