### PR TITLE
nuttx: Add basic PWM support for stm32f7

### DIFF
--- a/src/modules/iotjs_module_stm32f7nucleo.c
+++ b/src/modules/iotjs_module_stm32f7nucleo.c
@@ -19,7 +19,12 @@
 
 jerry_value_t iotjs_init_stm32f7nucleo() {
   jerry_value_t stm32f7nucleo = jerry_create_object();
-  /* Hardware support in progress, do initialization here */
+/* Hardware support in progress, do initialization here */
 
+#if defined(__NUTTX__)
+
+  iotjs_stm32f7nucleo_pin_initialize(stm32f7nucleo);
+
+#endif
   return stm32f7nucleo;
 }

--- a/src/modules/iotjs_module_stm32f7nucleo.h
+++ b/src/modules/iotjs_module_stm32f7nucleo.h
@@ -17,4 +17,7 @@
 #define IOTJS_MODULE_STM32F4DIS_H
 
 
+void iotjs_stm32f7nucleo_pin_initialize(jerry_value_t jobj);
+
+
 #endif /* IOTJS_MODULE_STM32F4DIS_H */

--- a/src/modules/nuttx/iotjs_module_stm32f7nucleo-nuttx.c
+++ b/src/modules/nuttx/iotjs_module_stm32f7nucleo-nuttx.c
@@ -15,8 +15,116 @@
 
 #if defined(__NUTTX__) && (TARGET_BOARD == stm32f7nucleo)
 
+#include "iotjs_systemio-nuttx.h"
+#include "stm32_gpio.h"
 
 #include "iotjs_def.h"
 #include "modules/iotjs_module_stm32f7nucleo.h"
+
+#if ENABLE_MODULE_GPIO
+
+static void iotjs_pin_initialize_gpio(jerry_value_t jobj) {
+// Set GPIO pin from configuration bits of nuttx.
+// GPIO pin name is "P(port)(pin)".
+#define SET_GPIO_CONSTANT(port, pin)                   \
+  iotjs_jval_set_property_number(jobj, "P" #port #pin, \
+                                 (GPIO_PORT##port | GPIO_PIN##pin));
+
+#define SET_GPIO_CONSTANT_PORT(port) \
+  SET_GPIO_CONSTANT(port, 0);        \
+  SET_GPIO_CONSTANT(port, 1);        \
+  SET_GPIO_CONSTANT(port, 2);        \
+  SET_GPIO_CONSTANT(port, 3);        \
+  SET_GPIO_CONSTANT(port, 4);        \
+  SET_GPIO_CONSTANT(port, 5);        \
+  SET_GPIO_CONSTANT(port, 6);        \
+  SET_GPIO_CONSTANT(port, 7);        \
+  SET_GPIO_CONSTANT(port, 8);        \
+  SET_GPIO_CONSTANT(port, 9);        \
+  SET_GPIO_CONSTANT(port, 10);       \
+  SET_GPIO_CONSTANT(port, 11);       \
+  SET_GPIO_CONSTANT(port, 12);       \
+  SET_GPIO_CONSTANT(port, 13);       \
+  SET_GPIO_CONSTANT(port, 14);       \
+  SET_GPIO_CONSTANT(port, 15);
+
+  SET_GPIO_CONSTANT_PORT(A);
+  SET_GPIO_CONSTANT_PORT(B);
+  SET_GPIO_CONSTANT_PORT(C);
+  SET_GPIO_CONSTANT_PORT(D);
+  SET_GPIO_CONSTANT_PORT(E);
+
+  SET_GPIO_CONSTANT(H, 0);
+  SET_GPIO_CONSTANT(H, 1);
+
+#undef SET_GPIO_CONSTANT_PORT
+#undef SET_GPIO_CONSTANT
+}
+
+#endif /* ENABLE_MODULE_GPIO */
+
+
+#if ENABLE_MODULE_PWM
+
+static void iotjs_pin_initialize_pwm(jerry_value_t jobj) {
+  unsigned int timer_bit;
+
+// Set PWM pin from configuration bits of nuttx.
+// PWM pin name is "PWM(timer).CH(channel)_(n)".
+#define SET_GPIO_CONSTANT(timer, channel, order)                        \
+  timer_bit = (GPIO_TIM##timer##_CH##channel##OUT_##order);             \
+  timer_bit |= (SYSIO_TIMER_NUMBER(timer));                             \
+  iotjs_jval_set_property_number(jtim##timer, "CH" #channel "_" #order, \
+                                 timer_bit);
+
+#define SET_GPIO_CONSTANT_CHANNEL(timer, channel) \
+  SET_GPIO_CONSTANT(timer, channel, 1);
+
+#define SET_GPIO_CONSTANT_TIM(timer)                 \
+  jerry_value_t jtim##timer = jerry_create_object(); \
+  iotjs_jval_set_property_jval(jobj, "PWM" #timer, jtim##timer);
+
+
+#define SET_GPIO_CONSTANT_TIM_1(timer) \
+  SET_GPIO_CONSTANT_TIM(timer);        \
+  SET_GPIO_CONSTANT_CHANNEL(timer, 1);
+
+  SET_GPIO_CONSTANT_TIM_1(1);
+  jerry_release_value(jtim1);
+
+  SET_GPIO_CONSTANT_TIM_1(2);
+  jerry_release_value(jtim2);
+
+  SET_GPIO_CONSTANT_TIM_1(3);
+  jerry_release_value(jtim3);
+
+  SET_GPIO_CONSTANT_TIM_1(4);
+  jerry_release_value(jtim4);
+
+#undef SET_GPIO_CONSTANT_TIM_1
+#undef SET_GPIO_CONSTANT_TIM_2
+#undef SET_GPIO_CONSTANT_TIM
+#undef SET_GPIO_CONSTANT_CHANNEL
+#undef SET_GPIO_CONSTANT
+}
+
+#endif /* ENABLE_MODULE_PWM */
+
+
+void iotjs_stm32f7nucleo_pin_initialize(jerry_value_t jobj) {
+  jerry_value_t jpin = jerry_create_object();
+  iotjs_jval_set_property_jval(jobj, "pin", jpin);
+
+#if ENABLE_MODULE_GPIO
+  iotjs_pin_initialize_gpio(jpin);
+#endif /* ENABLE_MODULE_GPIO */
+
+#if ENABLE_MODULE_PWM
+  iotjs_pin_initialize_pwm(jpin);
+#endif /* ENABLE_MODULE_PWM */
+
+  jerry_release_value(jpin);
+}
+
 
 #endif // __NUTTX__


### PR DESCRIPTION
It was tested on Nucleo-f767ZI with 4 servo motors:

* PWM1.CH1_1@PA8
* PWM2.CH1_1@PA0
* PWM3.CH1_1@PA6
* PWM4.CH1_1@PB6

Relate-to: https://github.com/rzr/webthing-iotjs/issues/3
Forwarded: https://github.com/pando-project/iotjs/pull
Change-Id: I8e195443b1bdcd56258e9bc635e3449dd037de5d
IoT.js-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com